### PR TITLE
fix: image links referencing local images in snippets

### DIFF
--- a/snippets/tool-section.mdx
+++ b/snippets/tool-section.mdx
@@ -14,7 +14,7 @@ export const ToolSection = ({ type, outputs, title, productSlug, apiSlug }) => (
                 loop
               />
             ) : (
-              <img height="320" className="rounded-lg h-80" src={output.src} />
+              <img height="320" className="rounded-lg h-80" src={output.src.startsWith('http') ?  output.src : `https://mintlify.s3.us-west-1.amazonaws.com/magichour${output.src}`} />
             )}
           </Frame>
         </Tab>


### PR DESCRIPTION
seems like using snippets means the image are not compiled into the right url. so just hacking it by hardcoding it for now