### PR TITLE
feat: generate mdx files for api reference

### DIFF
--- a/api-reference/files/generate-asset-upload-urls.mdx
+++ b/api-reference/files/generate-asset-upload-urls.mdx
@@ -1,0 +1,4 @@
+---
+openapi: post /v1/files/upload-urls
+title: "Upload Asset URLs"
+---

--- a/api-reference/image-projects/ai-clothes-changer.mdx
+++ b/api-reference/image-projects/ai-clothes-changer.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/ai-clothes-changer
+---

--- a/api-reference/image-projects/ai-headshots.mdx
+++ b/api-reference/image-projects/ai-headshots.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/ai-headshot-generator
+---

--- a/api-reference/image-projects/ai-image-upscaler.mdx
+++ b/api-reference/image-projects/ai-image-upscaler.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/ai-image-upscaler
+---

--- a/api-reference/image-projects/ai-images.mdx
+++ b/api-reference/image-projects/ai-images.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/ai-image-generator
+---

--- a/api-reference/image-projects/ai-photo-editor.mdx
+++ b/api-reference/image-projects/ai-photo-editor.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/ai-photo-editor
+---

--- a/api-reference/image-projects/ai-qr-code.mdx
+++ b/api-reference/image-projects/ai-qr-code.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/ai-qr-code-generator
+---

--- a/api-reference/image-projects/delete-image.mdx
+++ b/api-reference/image-projects/delete-image.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/image-projects/{id}
+---

--- a/api-reference/image-projects/face-swap-photo.mdx
+++ b/api-reference/image-projects/face-swap-photo.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/face-swap-photo
+---

--- a/api-reference/image-projects/get-image-details.mdx
+++ b/api-reference/image-projects/get-image-details.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/image-projects/{id}
+---

--- a/api-reference/image-projects/image-background-remover.mdx
+++ b/api-reference/image-projects/image-background-remover.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/image-background-remover
+---

--- a/api-reference/video-projects/animation.mdx
+++ b/api-reference/video-projects/animation.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/animation
+---

--- a/api-reference/video-projects/delete-video.mdx
+++ b/api-reference/video-projects/delete-video.mdx
@@ -1,0 +1,3 @@
+---
+openapi: delete /v1/video-projects/{id}
+---

--- a/api-reference/video-projects/face-swap-video.mdx
+++ b/api-reference/video-projects/face-swap-video.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/face-swap
+---

--- a/api-reference/video-projects/get-video-details.mdx
+++ b/api-reference/video-projects/get-video-details.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/video-projects/{id}
+---

--- a/api-reference/video-projects/image-to-video.mdx
+++ b/api-reference/video-projects/image-to-video.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/image-to-video
+---

--- a/api-reference/video-projects/lip-sync.mdx
+++ b/api-reference/video-projects/lip-sync.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/lip-sync
+---

--- a/api-reference/video-projects/text-to-video.mdx
+++ b/api-reference/video-projects/text-to-video.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/text-to-video
+---

--- a/api-reference/video-projects/video-to-video.mdx
+++ b/api-reference/video-projects/video-to-video.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/video-to-video
+---

--- a/changelog/2024.mdx
+++ b/changelog/2024.mdx
@@ -141,7 +141,7 @@ Now you can create stop-motion animations via API. Get started with this new API
 - [Node SDK](https://github.com/magichourhq/magic-hour-node/tree/main/src/resources/v1/animation)
 - [Go SDK](https://github.com/magichourhq/magic-hour-go/tree/main/resources/v1/animation)
 - [Rust SDK](https://github.com/magichourhq/magic-hour-rust/tree/main/src/resources/v1/animation)
-- [Rest API](/api-reference/image-projects/animation)
+- [Rest API](/api-reference/video-projects/animation)
 
 <Note>Fun Fact: Animation was the first mode we built on Magic Hour!</Note>
 

--- a/docs.json
+++ b/docs.json
@@ -94,7 +94,41 @@
       },
       {
         "tab": "API Reference",
-        "openapi": "https://magichour.ai/docs/api/openapi.json"
+        "openapi": "https://magichour.ai/docs/api/openapi.json",
+        "pages": [
+          {
+            "group": "Files",
+            "pages": ["api-reference/files/generate-asset-upload-urls"]
+          },
+          {
+            "group": "Video Projects",
+            "pages": [
+              "api-reference/video-projects/get-video-details",
+              "api-reference/video-projects/delete-video",
+              "api-reference/video-projects/animation",
+              "api-reference/video-projects/face-swap-video",
+              "api-reference/video-projects/image-to-video",
+              "api-reference/video-projects/lip-sync",
+              "api-reference/video-projects/video-to-video",
+              "api-reference/video-projects/text-to-video"
+            ]
+          },
+          {
+            "group": "Image Projects",
+            "pages": [
+              "api-reference/image-projects/get-image-details",
+              "api-reference/image-projects/delete-image",
+              "api-reference/image-projects/ai-clothes-changer",
+              "api-reference/image-projects/ai-headshots",
+              "api-reference/image-projects/ai-images",
+              "api-reference/image-projects/ai-image-upscaler",
+              "api-reference/image-projects/ai-photo-editor",
+              "api-reference/image-projects/ai-qr-code",
+              "api-reference/image-projects/face-swap-photo",
+              "api-reference/image-projects/image-background-remover"
+            ]
+          }
+        ]
       },
       {
         "tab": "Webhook Reference",
@@ -120,11 +154,7 @@
       },
       {
         "tab": "Changelog",
-        "pages": [
-          "changelog",
-          "changelog/2024",
-          "changelog/2023"
-        ]
+        "pages": ["changelog", "changelog/2024", "changelog/2023"]
       }
     ],
     "global": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "dev": "mintlify dev --port 3001",
     "check": "mintlify broken-links",
-    "scrap:api": "mintlify-scrape openapi-file https://magichour.ai/docs/api/openapi.json -o api-reference",
-    "scrap:webhook": "mintlify-scrape openapi-file https://magichour.ai/docs/webhook/openapi.json -o webhook-reference"
+    "scrape:api": "mintlify-scrape openapi-file https://magichour.ai/docs/api/openapi.json -o api-reference",
+    "scrape:webhook": "mintlify-scrape openapi-file https://magichour.ai/docs/webhook/openapi.json -o webhook-reference"
   },
   "devDependencies": {
     "@mintlify/scraping": "4.0.154",


### PR DESCRIPTION
this make sure `yarn check` validates broken links properly. currently, it outputs all /api-reference as broken. This also allow us to customize the API doc