### PR TITLE
feat: update-order-of-contextual menu to show chatgpt first

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -198,6 +198,6 @@
     }
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "perplexity", "mcp", "cursor", "vscode"]
+    "options": ["chatgpt", "claude", "perplexity", "mcp", "cursor", "vscode", "copy", "view"]
   }
 }


### PR DESCRIPTION
the current "Copy page" isn't really useful. 