### PR TITLE
feat: create distinct page titles and descriptions for API reference vs tools

### DIFF
--- a/api-reference/audio-projects/ai-voice-cloner.mdx
+++ b/api-reference/audio-projects/ai-voice-cloner.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-voice-cloner
-title: AI Voice Cloner API Reference
+title: AI Voice Cloner API Reference - Magic Hour Docs
 sidebarTitle: AI Voice Cloner
 ---

--- a/api-reference/audio-projects/ai-voice-generator.mdx
+++ b/api-reference/audio-projects/ai-voice-generator.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-voice-generator
-title: AI Voice Generator API Reference
+title: AI Voice Generator API Reference - Magic Hour Docs
 sidebarTitle: AI Voice Generator
 ---

--- a/api-reference/audio-projects/delete-audio.mdx
+++ b/api-reference/audio-projects/delete-audio.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: delete /v1/audio-projects/{id}
-title: Delete Audio API Reference
+title: Delete Audio API Reference - Magic Hour Docs
 sidebarTitle: Delete Audio
 ---

--- a/api-reference/audio-projects/get-audio-details.mdx
+++ b/api-reference/audio-projects/get-audio-details.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: get /v1/audio-projects/{id}
-title: Get Audio Details API Reference
+title: Get Audio Details API Reference - Magic Hour Docs
 sidebarTitle: Get Audio Details
 ---

--- a/api-reference/files/face-detection.mdx
+++ b/api-reference/files/face-detection.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/face-detection
-title: Face Detection API Reference
+title: Face Detection API Reference - Magic Hour Docs
 sidebarTitle: Face Detection
 ---

--- a/api-reference/files/generate-asset-upload-urls.mdx
+++ b/api-reference/files/generate-asset-upload-urls.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/files/upload-urls
-title: Generate Asset Upload Urls API Reference
+title: Generate Asset Upload Urls API Reference - Magic Hour Docs
 sidebarTitle: Generate Asset Upload Urls
 ---

--- a/api-reference/files/get-face-detection-details.mdx
+++ b/api-reference/files/get-face-detection-details.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: get /v1/face-detection/{id}
-title: Get Face Detection Details API Reference
+title: Get Face Detection Details API Reference - Magic Hour Docs
 sidebarTitle: Get Face Detection Details
 ---

--- a/api-reference/image-projects/ai-clothes-changer.mdx
+++ b/api-reference/image-projects/ai-clothes-changer.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-clothes-changer
-title: AI Clothes Changer API Reference
+title: AI Clothes Changer API Reference - Magic Hour Docs
 sidebarTitle: AI Clothes Changer
 ---

--- a/api-reference/image-projects/ai-face-editor.mdx
+++ b/api-reference/image-projects/ai-face-editor.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-face-editor
-title: AI Face Editor API Reference
+title: AI Face Editor API Reference - Magic Hour Docs
 sidebarTitle: AI Face Editor
 ---

--- a/api-reference/image-projects/ai-gif-generator.mdx
+++ b/api-reference/image-projects/ai-gif-generator.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-gif-generator
-title: AI GIF Generator API Reference
+title: AI GIF Generator API Reference - Magic Hour Docs
 sidebarTitle: AI GIF Generator
 ---

--- a/api-reference/image-projects/ai-headshot-generator.mdx
+++ b/api-reference/image-projects/ai-headshot-generator.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-headshot-generator
-title: AI Headshot Generator API Reference
+title: AI Headshot Generator API Reference - Magic Hour Docs
 sidebarTitle: AI Headshot Generator
 ---

--- a/api-reference/image-projects/ai-image-editor.mdx
+++ b/api-reference/image-projects/ai-image-editor.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-image-editor
-title: AI Image Editor API Reference
+title: AI Image Editor API Reference - Magic Hour Docs
 sidebarTitle: AI Image Editor
 ---

--- a/api-reference/image-projects/ai-image-generator.mdx
+++ b/api-reference/image-projects/ai-image-generator.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-image-generator
-title: AI Image Generator API Reference
+title: AI Image Generator API Reference - Magic Hour Docs
 sidebarTitle: AI Image Generator
 ---

--- a/api-reference/image-projects/ai-image-upscaler.mdx
+++ b/api-reference/image-projects/ai-image-upscaler.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-image-upscaler
-title: AI Image Upscaler API Reference
+title: AI Image Upscaler API Reference - Magic Hour Docs
 sidebarTitle: AI Image Upscaler
 ---

--- a/api-reference/image-projects/ai-meme-generator.mdx
+++ b/api-reference/image-projects/ai-meme-generator.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-meme-generator
-title: AI Meme Generator API Reference
+title: AI Meme Generator API Reference - Magic Hour Docs
 sidebarTitle: AI Meme Generator
 ---

--- a/api-reference/image-projects/ai-qr-code-generator.mdx
+++ b/api-reference/image-projects/ai-qr-code-generator.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-qr-code-generator
-title: AI QR Code Generator API Reference
+title: AI QR Code Generator API Reference - Magic Hour Docs
 sidebarTitle: AI QR Code Generator
 ---

--- a/api-reference/image-projects/delete-image.mdx
+++ b/api-reference/image-projects/delete-image.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: delete /v1/image-projects/{id}
-title: Delete Image API Reference
+title: Delete Image API Reference - Magic Hour Docs
 sidebarTitle: Delete Image
 ---

--- a/api-reference/image-projects/face-swap-photo.mdx
+++ b/api-reference/image-projects/face-swap-photo.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/face-swap-photo
-title: Face Swap Photo API Reference
+title: Face Swap Photo API Reference - Magic Hour Docs
 sidebarTitle: Face Swap Photo
 ---

--- a/api-reference/image-projects/get-image-details.mdx
+++ b/api-reference/image-projects/get-image-details.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: get /v1/image-projects/{id}
-title: Get Image Details API Reference
+title: Get Image Details API Reference - Magic Hour Docs
 sidebarTitle: Get Image Details
 ---

--- a/api-reference/image-projects/head-swap.mdx
+++ b/api-reference/image-projects/head-swap.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /v1/head-swap
+title: Head Swap API Reference - Magic Hour Docs
+sidebarTitle: Head Swap
 ---

--- a/api-reference/image-projects/image-background-remover.mdx
+++ b/api-reference/image-projects/image-background-remover.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/image-background-remover
-title: Image Background Remover API Reference
+title: Image Background Remover API Reference - Magic Hour Docs
 sidebarTitle: Image Background Remover
 ---

--- a/api-reference/image-projects/photo-colorizer.mdx
+++ b/api-reference/image-projects/photo-colorizer.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/photo-colorizer
-title: Photo Colorizer API Reference
+title: Photo Colorizer API Reference - Magic Hour Docs
 sidebarTitle: Photo Colorizer
 ---

--- a/api-reference/video-projects/ai-talking-photo.mdx
+++ b/api-reference/video-projects/ai-talking-photo.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/ai-talking-photo
-title: AI Talking Photo API Reference
+title: AI Talking Photo API Reference - Magic Hour Docs
 sidebarTitle: AI Talking Photo
 ---

--- a/api-reference/video-projects/animation.mdx
+++ b/api-reference/video-projects/animation.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/animation
-title: Animation API Reference
+title: Animation API Reference - Magic Hour Docs
 sidebarTitle: Animation
 ---

--- a/api-reference/video-projects/auto-subtitle-generator.mdx
+++ b/api-reference/video-projects/auto-subtitle-generator.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/auto-subtitle-generator
-title: Auto Subtitle Generator API Reference
+title: Auto Subtitle Generator API Reference - Magic Hour Docs
 sidebarTitle: Auto Subtitle Generator
 ---

--- a/api-reference/video-projects/delete-video.mdx
+++ b/api-reference/video-projects/delete-video.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: delete /v1/video-projects/{id}
-title: Delete Video API Reference
+title: Delete Video API Reference - Magic Hour Docs
 sidebarTitle: Delete Video
 ---

--- a/api-reference/video-projects/face-swap-video.mdx
+++ b/api-reference/video-projects/face-swap-video.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/face-swap
-title: Face Swap Video API Reference
+title: Face Swap Video API Reference - Magic Hour Docs
 sidebarTitle: Face Swap Video
 ---

--- a/api-reference/video-projects/get-video-details.mdx
+++ b/api-reference/video-projects/get-video-details.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: get /v1/video-projects/{id}
-title: Get Video Details API Reference
+title: Get Video Details API Reference - Magic Hour Docs
 sidebarTitle: Get Video Details
 ---

--- a/api-reference/video-projects/image-to-video.mdx
+++ b/api-reference/video-projects/image-to-video.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/image-to-video
-title: Image-to-Video API Reference
+title: Image-to-Video API Reference - Magic Hour Docs
 sidebarTitle: Image-to-Video
 ---

--- a/api-reference/video-projects/lip-sync.mdx
+++ b/api-reference/video-projects/lip-sync.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/lip-sync
-title: Lip Sync API Reference
+title: Lip Sync API Reference - Magic Hour Docs
 sidebarTitle: Lip Sync
 ---

--- a/api-reference/video-projects/text-to-video.mdx
+++ b/api-reference/video-projects/text-to-video.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/text-to-video
-title: Text-to-Video API Reference
+title: Text-to-Video API Reference - Magic Hour Docs
 sidebarTitle: Text-to-Video
 ---

--- a/api-reference/video-projects/video-to-video.mdx
+++ b/api-reference/video-projects/video-to-video.mdx
@@ -1,5 +1,5 @@
 ---
 openapi: post /v1/video-to-video
-title: Video-to-Video API Reference
+title: Video-to-Video API Reference - Magic Hour Docs
 sidebarTitle: Video-to-Video
 ---

--- a/docs.json
+++ b/docs.json
@@ -125,10 +125,7 @@
               },
               {
                 "group": "Audio",
-                "pages": [
-                  "tools/audio/voice-cloner",
-                  "tools/audio/voice-generator"
-                ]
+                "pages": ["tools/audio/voice-cloner", "tools/audio/voice-generator"]
               }
             ]
           }
@@ -227,12 +224,7 @@
         "pages": [
           {
             "group": "Product Updates",
-            "pages": [
-              "changelog",
-              "changelog/2025",
-              "changelog/2024",
-              "changelog/2023"
-            ]
+            "pages": ["changelog", "changelog/2025", "changelog/2024", "changelog/2023"]
           }
         ]
       }
@@ -262,15 +254,6 @@
     }
   },
   "contextual": {
-    "options": [
-      "chatgpt",
-      "claude",
-      "perplexity",
-      "mcp",
-      "cursor",
-      "vscode",
-      "copy",
-      "view"
-    ]
+    "options": ["chatgpt", "claude", "perplexity", "mcp", "cursor", "vscode", "copy", "view"]
   }
 }

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -76,10 +76,8 @@ MAGIC_HOUR_API_KEY=your_api_key_here
 ```
 
 <Warning>
-**Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately:
-```bash
-echo ".env" >> .gitignore
-```
+  **Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately: ```bash
+  echo ".env" >> .gitignore ```
 </Warning>
 
 ### Step 4: Write the Integration Code
@@ -316,10 +314,8 @@ MAGIC_HOUR_API_KEY=your_api_key_here
 ```
 
 <Warning>
-**Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately:
-```bash
-echo ".env" >> .gitignore
-```
+  **Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately: ```bash
+  echo ".env" >> .gitignore ```
 </Warning>
 
 ### Step 4: Write the Integration Code

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -76,9 +76,12 @@ MAGIC_HOUR_API_KEY=your_api_key_here
 ```
 
 <Warning>
-  **Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately: ```bash
-  echo ".env" >> .gitignore ```
+  **Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately.
 </Warning>
+
+```bash
+echo ".env" >> .gitignore
+```
 
 ### Step 4: Write the Integration Code
 
@@ -314,9 +317,12 @@ MAGIC_HOUR_API_KEY=your_api_key_here
 ```
 
 <Warning>
-  **Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately: ```bash
-  echo ".env" >> .gitignore ```
+  **Security**: Never commit `.env` to version control. Add it to `.gitignore` immediately.
 </Warning>
+
+```bash
+echo ".env" >> .gitignore
+```
 
 ### Step 4: Write the Integration Code
 

--- a/tools/audio/voice-cloner.mdx
+++ b/tools/audio/voice-cloner.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Voice Cloner
+title: AI Voice Cloner Tool - Magic Hour Docs
 sidebarTitle: Voice Cloner
 description: Clone any voice and generate realistic speech audio from text using custom voice samples.
 ---

--- a/tools/audio/voice-generator.mdx
+++ b/tools/audio/voice-generator.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Voice Generator
+title: AI Voice Generator Tool - Magic Hour Docs
 sidebarTitle: Voice Generator
 description: Generate realistic speech audio from text using celebrity and character voices.
 ---

--- a/tools/image/background-remover.mdx
+++ b/tools/image/background-remover.mdx
@@ -1,5 +1,5 @@
 ---
-title: Image Background Remover
+title: Image Background Remover Tool - Magic Hour Docs
 sidebarTitle: Background Remover
 description: Automatically remove backgrounds from images with precision edge detection.
 ---

--- a/tools/image/clothes-changer.mdx
+++ b/tools/image/clothes-changer.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Clothes Changer
+title: AI Clothes Changer Tool - Magic Hour Docs
 sidebarTitle: Clothes Changer
 description: Virtually try on different clothing items with realistic results.
 ---

--- a/tools/image/face-editor.mdx
+++ b/tools/image/face-editor.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Face Editor
+title: AI Face Editor Tool - Magic Hour Docs
 sidebarTitle: Face Editor
 description: Edit and enhance facial features with AI-powered precision and natural results.
 ---

--- a/tools/image/face-swap-photo.mdx
+++ b/tools/image/face-swap-photo.mdx
@@ -1,5 +1,5 @@
 ---
-title: Face Swap Photo
+title: Face Swap Photo Tool - Magic Hour Docs
 sidebarTitle: Face Swap Photo
 description: Replace faces in photos with realistic precision and natural blending.
 ---

--- a/tools/image/gif-generator.mdx
+++ b/tools/image/gif-generator.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI GIF Generator
+title: AI GIF Generator Tool - Magic Hour Docs
 sidebarTitle: GIF Generator
 description: Create animated GIFs from images or text prompts with AI-powered generation.
 ---

--- a/tools/image/headshot-generator.mdx
+++ b/tools/image/headshot-generator.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Headshot Generator
+title: AI Headshot Generator Tool - Magic Hour Docs
 sidebarTitle: Headshot Generator
 description: Generate professional-quality headshots from a single photo.
 ---

--- a/tools/image/image-editor.mdx
+++ b/tools/image/image-editor.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Image Editor
+title: AI Image Editor Tool - Magic Hour Docs
 sidebarTitle: Image Editor
 description: Edit and modify images with AI-powered tools for comprehensive image manipulation.
 ---

--- a/tools/image/image-generator.mdx
+++ b/tools/image/image-generator.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Image Generator
+title: AI Image Generator Tool - Magic Hour Docs
 sidebarTitle: Image Generator
 description: Create high-quality images from text descriptions using AI.
 ---

--- a/tools/image/image-upscaler.mdx
+++ b/tools/image/image-upscaler.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Image Upscaler
+title: AI Image Upscaler Tool - Magic Hour Docs
 sidebarTitle: Image Upscaler
 description: Enhance image resolution and quality using AI-powered upscaling.
 ---

--- a/tools/image/meme-generator.mdx
+++ b/tools/image/meme-generator.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Meme Generator
+title: AI Meme Generator Tool - Magic Hour Docs
 sidebarTitle: Meme Generator
 description: Create AI-generated memes using popular templates and custom topics.
 ---

--- a/tools/image/photo-colorizer.mdx
+++ b/tools/image/photo-colorizer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Photo Colorizer
+title: Photo Colorizer Tool - Magic Hour Docs
 sidebarTitle: Photo Colorizer
 description: Colorize black and white photos with AI-powered realistic color restoration.
 ---

--- a/tools/image/qr-code-generator.mdx
+++ b/tools/image/qr-code-generator.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI QR Code Generator
+title: AI QR Code Generator Tool - Magic Hour Docs
 sidebarTitle: QR Code Generator
 description: Create visually appealing, artistic QR codes that maintain functionality.
 ---

--- a/tools/video/animation.mdx
+++ b/tools/video/animation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Animation
+title: Animation Tool - Magic Hour Docs
 sidebarTitle: Animation
 description: Transform static images into dynamic animated videos with smooth motion.
 ---

--- a/tools/video/auto-subtitle-generator.mdx
+++ b/tools/video/auto-subtitle-generator.mdx
@@ -1,5 +1,5 @@
 ---
-title: Auto Subtitle Generator
+title: Auto Subtitle Generator Tool - Magic Hour Docs
 sidebarTitle: Auto Subtitle
 description: Automatically generate and embed subtitles in videos with AI-powered transcription.
 ---

--- a/tools/video/face-swap-video.mdx
+++ b/tools/video/face-swap-video.mdx
@@ -1,5 +1,5 @@
 ---
-title: Face Swap Video
+title: Face Swap Video Tool - Magic Hour Docs
 sidebarTitle: Face Swap Video
 description: Replace faces in videos with frame-by-frame precision and temporal consistency.
 ---

--- a/tools/video/image-to-video.mdx
+++ b/tools/video/image-to-video.mdx
@@ -1,5 +1,5 @@
 ---
-title: Image to Video
+title: Image to Video Tool - Magic Hour Docs
 sidebarTitle: Image to Video
 description: Convert static images into dynamic video content with AI-generated motion.
 ---

--- a/tools/video/lip-sync.mdx
+++ b/tools/video/lip-sync.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lip Sync
+title: Lip Sync Tool - Magic Hour Docs
 sidebarTitle: Lip Sync
 description: Synchronize lip movements in videos with new audio tracks.
 ---

--- a/tools/video/talking-photo.mdx
+++ b/tools/video/talking-photo.mdx
@@ -1,5 +1,5 @@
 ---
-title: AI Talking Photo
+title: AI Talking Photo Tool - Magic Hour Docs
 sidebarTitle: Talking Photo
 description: Animate static photos to speak with realistic lip-sync and facial movements.
 ---

--- a/tools/video/text-to-video.mdx
+++ b/tools/video/text-to-video.mdx
@@ -1,5 +1,5 @@
 ---
-title: Text to Video
+title: Text to Video Tool - Magic Hour Docs
 sidebarTitle: Text to Video
 description: Generate complete video content from text descriptions using AI.
 ---

--- a/tools/video/video-to-video.mdx
+++ b/tools/video/video-to-video.mdx
@@ -1,5 +1,5 @@
 ---
-title: Video to Video
+title: Video to Video Tool - Magic Hour Docs
 sidebarTitle: Video to Video
 description: Transform existing videos by applying new styles, effects, and visual treatments.
 ---

--- a/webhook-reference/audio-events/audio-completed.mdx
+++ b/webhook-reference/audio-events/audio-completed.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /audio.completed
+description: Magic Hour notifies your server when an audio generation completes successfully. Payload covers downloads, credits, duration, and how to verify the incoming signed request.
 ---

--- a/webhook-reference/audio-events/audio-errored.mdx
+++ b/webhook-reference/audio-events/audio-errored.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /audio.errored
+description: Magic Hour notifies your server when an audio project fails. Error-focused webhook reference with request headers, body fields, and examples for your failure-handling logic.
 ---

--- a/webhook-reference/audio-events/audio-started.mdx
+++ b/webhook-reference/audio-events/audio-started.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /audio.started
+description: Magic Hour notifies your server when an audio project begins processing. Webhook reference for timestamp and signature headers plus JSON body for voice and audio jobs.
 ---

--- a/webhook-reference/image-events/image-completed.mdx
+++ b/webhook-reference/image-events/image-completed.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /image.completed
+description: Magic Hour notifies your server when an image project completes. Reference download arrays, credits, image count, project type, and verified request shape for integrations.
 ---

--- a/webhook-reference/image-events/image-errored.mdx
+++ b/webhook-reference/image-events/image-errored.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /image.errored
+description: Magic Hour notifies your server when an image project fails. Use this page for error payload fields, project metadata, and validating signed webhook requests from Magic Hour.
 ---

--- a/webhook-reference/image-events/image-started.mdx
+++ b/webhook-reference/image-events/image-started.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /image.started
+description: Magic Hour notifies your server when an image project begins processing. Document signature headers, JSON schema, and example payload for image-generation webhooks.
 ---

--- a/webhook-reference/video-events/video-completed.mdx
+++ b/webhook-reference/video-events/video-completed.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /video.completed
+description: Magic Hour notifies your server when a video project finishes successfully. Payload includes download URLs, dimensions, credits charged, and fields to verify with the Get Video Details API.
 ---

--- a/webhook-reference/video-events/video-errored.mdx
+++ b/webhook-reference/video-events/video-errored.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /video.errored
+description: Magic Hour notifies your server when a video project fails. Webhook reference for error code, message, project id, and HMAC-signed headers your endpoint should validate.
 ---

--- a/webhook-reference/video-events/video-started.mdx
+++ b/webhook-reference/video-events/video-started.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /video.started
+description: Magic Hour notifies your server when a video project begins processing. Reference signed headers, JSON payload fields, and example body for your webhook handler.
 ---


### PR DESCRIPTION
Updates Mintlify `title` frontmatter so API reference and tool guide pages no longer share ambiguous browser titles.

**API reference** (`/api-reference/...`): `{Name} API Reference - Magic Hour Docs`

**Tool guides** (`/tools/...`): `{Name} Tool - Magic Hour Docs`

Also adds a title for the head-swap API page (previously missing) and applies Prettier repo-wide (`docs.json`, `integration/first-integration.mdx`, and minor MDX normalization).

Made with [Cursor](https://cursor.com)