### PR TITLE
feat: clarify onboarding lifecycle and fix webhook CDN examples

### DIFF
--- a/get-started/quick-start.mdx
+++ b/get-started/quick-start.mdx
@@ -5,7 +5,7 @@ description: "Generate an API key and make your first call in <3 minutes."
 
 Magic Hour is an AI video and image generation platform. You submit a job, we render it, and you download the result. This guide gets you to your first output in a few minutes.
 
-```mermaid
+<Mermaid actions={false}>
 flowchart LR
     A["Create job"] --> B["Receive project ID"]
     B --> C["Wait"]
@@ -14,7 +14,7 @@ flowchart LR
     D --> F["Receive webhook"]
     E --> G["Download result"]
     F --> G
-```
+</Mermaid>
 
 <Card
   title="Skip local setup — open the Google Colab cookbook"

--- a/get-started/quick-start.mdx
+++ b/get-started/quick-start.mdx
@@ -5,6 +5,26 @@ description: "Generate an API key and make your first call in <3 minutes."
 
 Magic Hour is an AI video and image generation platform. You submit a job, we render it, and you download the result. This guide gets you to your first output in a few minutes.
 
+```mermaid
+flowchart LR
+    A["Create job"] --> B["Receive project ID"]
+    B --> C["Wait"]
+    C --> D{"Track completion"}
+    D --> E["Poll project"]
+    D --> F["Receive webhook"]
+    E --> G["Download result"]
+    F --> G
+```
+
+<Card
+  title="Skip local setup — open the Google Colab cookbook"
+  icon="code"
+  href="https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing"
+  openInNewTab
+>
+  Try every API from your browser with only an API key.
+</Card>
+
 **What you'll accomplish:**
 
 1. **Create an API key** - Get credentials to authenticate with our API
@@ -25,7 +45,11 @@ Magic Hour is an AI video and image generation platform. You submit a job, we re
 2. Click **Create key**, give it a name (e.g., "My First Project"), and create it.
 3. **Copy the API key immediately** — you won't be able to see it again.
 
-<Card title="Need the full walkthrough?" icon="key" href="/get-started/authentication#creating-your-first-api-key">
+<Card
+  title="Need the full walkthrough?"
+  icon="key"
+  href="/get-started/authentication#creating-your-first-api-key"
+>
   See screenshots, permissions, and key-management guidance in the Authentication guide.
 </Card>
 
@@ -111,9 +135,9 @@ import SdkInstallation from "/snippets/code-groups/sdk-installation.mdx";
 <SdkInstallation />
 
 <Tip>
-  Want to test your integration without spending credits? The SDKs include a
-  [mock server](/integration/development-and-testing#mock-server-recommended-for-development) that
-  returns sample responses instantly.
+  Want to test your integration without spending credits? The SDKs include a [mock
+  server](/integration/development-and-testing#mock-server-recommended-for-development) that returns
+  sample responses instantly.
 </Tip>
 
 ## 3. Generate your first output
@@ -121,10 +145,10 @@ import SdkInstallation from "/snippets/code-groups/sdk-installation.mdx";
 **What we're doing:** Submit a generation job, wait for Magic Hour to render it, then download the
 result. Choose the example that matches what you want to build:
 
-| Example | Best for | Typical cost | Typical wait |
-| :------ | :------- | :----------- | :----------- |
-| **Generate image** | Cheapest first success | 5 credits | 30-60 seconds |
-| **Face swap video** | Our most popular API path | ~200 credits for the sample clip | 2-5 minutes |
+| Example             | Best for                  | Typical cost                     | Typical wait  |
+| :------------------ | :------------------------ | :------------------------------- | :------------ |
+| **Generate image**  | Cheapest first success    | 5 credits                        | 30-60 seconds |
+| **Face swap video** | Our most popular API path | ~200 credits for the sample clip | 2-5 minutes   |
 
 ### Copy the code and run it
 

--- a/get-started/quick-start.mdx
+++ b/get-started/quick-start.mdx
@@ -5,17 +5,6 @@ description: "Generate an API key and make your first call in <3 minutes."
 
 Magic Hour is an AI video and image generation platform. You submit a job, we render it, and you download the result. This guide gets you to your first output in a few minutes.
 
-<Mermaid actions={false}>
-flowchart LR
-    A["Create job"] --> B["Receive project ID"]
-    B --> C["Wait"]
-    C --> D{"Track completion"}
-    D --> E["Poll project"]
-    D --> F["Receive webhook"]
-    E --> G["Download result"]
-    F --> G
-</Mermaid>
-
 <Card
   title="Skip local setup — open the Google Colab cookbook"
   icon="code"

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -6,16 +6,17 @@ description: Build a complete Magic Hour integration from scratch in this hands-
 
 Every generation follows the same lifecycle:
 
-```mermaid actions=false
-flowchart LR
+<Mermaid
+  actions={false}
+  chart={`flowchart LR
     A["Create job"] --> B["Receive project ID"]
     B --> C["Wait"]
     C --> D{"Track completion"}
     D --> E["Poll project"]
     D --> F["Receive webhook"]
     E --> G["Download result"]
-    F --> G
-```
+    F --> G`}
+/>
 
 <Card
   title="Prefer an interactive browser notebook?"

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -6,17 +6,58 @@ description: Build a complete Magic Hour integration from scratch in this hands-
 
 Every generation follows the same lifecycle:
 
-<Mermaid
-  actions={false}
-  chart={`flowchart LR
-    A["Create job"] --> B["Receive project ID"]
-    B --> C["Wait"]
-    C --> D{"Track completion"}
-    D --> E["Poll project"]
-    D --> F["Receive webhook"]
-    E --> G["Download result"]
-    F --> G`}
-/>
+<svg
+  viewBox="0 0 900 180"
+  role="img"
+  aria-labelledby="generation-lifecycle-title"
+  className="my-6 h-auto w-full text-gray-700 dark:text-gray-300"
+>
+  <title id="generation-lifecycle-title">
+    Create a job, receive its project ID, wait for completion through polling or a webhook, then
+    download the result.
+  </title>
+  <defs>
+    <marker
+      id="lifecycle-arrow"
+      viewBox="0 0 10 10"
+      refX="9"
+      refY="5"
+      markerWidth="6"
+      markerHeight="6"
+      orient="auto-start-reverse"
+    >
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+    </marker>
+  </defs>
+
+  <g fill="none" stroke="currentColor" strokeWidth="1.5">
+    <rect x="10" y="65" width="105" height="50" />
+    <rect x="155" y="65" width="145" height="50" />
+    <rect x="340" y="65" width="80" height="50" />
+    <path d="M 490 25 L 555 90 L 490 155 L 425 90 Z" />
+    <rect x="600" y="20" width="115" height="50" />
+    <rect x="600" y="110" width="115" height="50" />
+    <rect x="760" y="65" width="130" height="50" />
+
+    <path d="M 115 90 H 155" markerEnd="url(#lifecycle-arrow)" />
+    <path d="M 300 90 H 340" markerEnd="url(#lifecycle-arrow)" />
+    <path d="M 420 90 H 425" markerEnd="url(#lifecycle-arrow)" />
+    <path d="M 535 45 H 600" markerEnd="url(#lifecycle-arrow)" />
+    <path d="M 535 135 H 600" markerEnd="url(#lifecycle-arrow)" />
+    <path d="M 715 45 C 745 45 730 90 760 90" markerEnd="url(#lifecycle-arrow)" />
+    <path d="M 715 135 C 745 135 730 90 760 90" markerEnd="url(#lifecycle-arrow)" />
+  </g>
+
+  <g fill="currentColor" textAnchor="middle" dominantBaseline="middle" fontSize="14">
+    <text x="62.5" y="90">Create job</text>
+    <text x="227.5" y="90">Receive project ID</text>
+    <text x="380" y="90">Wait</text>
+    <text x="490" y="90">Track completion</text>
+    <text x="657.5" y="45">Poll project</text>
+    <text x="657.5" y="135">Receive webhook</text>
+    <text x="825" y="90">Download result</text>
+  </g>
+</svg>
 
 <Card
   title="Prefer an interactive browser notebook?"

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -6,58 +6,52 @@ description: Build a complete Magic Hour integration from scratch in this hands-
 
 Every generation follows the same lifecycle:
 
-<svg
-  viewBox="0 0 900 180"
+<div
   role="img"
-  aria-labelledby="generation-lifecycle-title"
-  className="my-6 h-auto w-full text-gray-700 dark:text-gray-300"
+  aria-label="Create a job, receive its project ID, wait, track completion by polling or webhook, then download the result."
+  className="not-prose my-6 overflow-x-auto pb-2"
 >
-  <title id="generation-lifecycle-title">
-    Create a job, receive its project ID, wait for completion through polling or a webhook, then
-    download the result.
-  </title>
-  <defs>
-    <marker
-      id="lifecycle-arrow"
-      viewBox="0 0 10 10"
-      refX="9"
-      refY="5"
-      markerWidth="6"
-      markerHeight="6"
-      orient="auto-start-reverse"
+  <div
+    className="grid min-w-[860px] items-center gap-x-2 gap-y-3 text-center text-sm"
+    style={{
+      gridTemplateColumns: "105px 24px 145px 24px 70px 24px 130px 24px 125px 24px 130px",
+      gridTemplateRows: "48px 12px 48px",
+    }}
+  >
+    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+      Create job
+    </div>
+    <span style={{ gridRow: "1 / 4" }}>→</span>
+    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+      Receive project ID
+    </div>
+    <span style={{ gridRow: "1 / 4" }}>→</span>
+    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+      Wait
+    </div>
+    <span style={{ gridRow: "1 / 4" }}>→</span>
+    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+      Track completion
+    </div>
+    <span style={{ gridRow: "1" }}>↗</span>
+    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1" }}>
+      Poll project
+    </div>
+    <span style={{ gridRow: "1" }}>↘</span>
+    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+      Download result
+    </div>
+
+    <span style={{ gridColumn: "8", gridRow: "3" }}>↘</span>
+    <div
+      className="border border-gray-400 px-3 py-3 dark:border-gray-600"
+      style={{ gridColumn: "9", gridRow: "3" }}
     >
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
-    </marker>
-  </defs>
-
-  <g fill="none" stroke="currentColor" strokeWidth="1.5">
-    <rect x="10" y="65" width="105" height="50" />
-    <rect x="155" y="65" width="145" height="50" />
-    <rect x="340" y="65" width="80" height="50" />
-    <path d="M 490 25 L 555 90 L 490 155 L 425 90 Z" />
-    <rect x="600" y="20" width="115" height="50" />
-    <rect x="600" y="110" width="115" height="50" />
-    <rect x="760" y="65" width="130" height="50" />
-
-    <path d="M 115 90 H 155" markerEnd="url(#lifecycle-arrow)" />
-    <path d="M 300 90 H 340" markerEnd="url(#lifecycle-arrow)" />
-    <path d="M 420 90 H 425" markerEnd="url(#lifecycle-arrow)" />
-    <path d="M 535 45 H 600" markerEnd="url(#lifecycle-arrow)" />
-    <path d="M 535 135 H 600" markerEnd="url(#lifecycle-arrow)" />
-    <path d="M 715 45 C 745 45 730 90 760 90" markerEnd="url(#lifecycle-arrow)" />
-    <path d="M 715 135 C 745 135 730 90 760 90" markerEnd="url(#lifecycle-arrow)" />
-  </g>
-
-  <g fill="currentColor" textAnchor="middle" dominantBaseline="middle" fontSize="14">
-    <text x="62.5" y="90">Create job</text>
-    <text x="227.5" y="90">Receive project ID</text>
-    <text x="380" y="90">Wait</text>
-    <text x="490" y="90">Track completion</text>
-    <text x="657.5" y="45">Poll project</text>
-    <text x="657.5" y="135">Receive webhook</text>
-    <text x="825" y="90">Download result</text>
-  </g>
-</svg>
+      Receive webhook
+    </div>
+    <span style={{ gridColumn: "10", gridRow: "3" }}>↗</span>
+  </div>
+</div>
 
 <Card
   title="Prefer an interactive browser notebook?"

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -12,39 +12,39 @@ Every generation follows the same lifecycle:
   className="not-prose my-6 overflow-x-auto pb-2"
 >
   <div
-    className="grid min-w-[860px] items-center gap-x-2 gap-y-3 text-center text-sm"
+    className="grid w-full min-w-[600px] items-center gap-x-1 gap-y-3 text-center text-xs"
     style={{
-      gridTemplateColumns: "105px 24px 145px 24px 70px 24px 130px 24px 125px 24px 130px",
+      gridTemplateColumns: "1fr 12px 1.35fr 12px 0.65fr 12px 1.2fr 12px 1fr 12px 1.15fr",
       gridTemplateRows: "48px 12px 48px",
     }}
   >
-    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+    <div className="border border-gray-400 px-2 py-2 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
       Create job
     </div>
     <span style={{ gridRow: "1 / 4" }}>→</span>
-    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+    <div className="border border-gray-400 px-2 py-2 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
       Receive project ID
     </div>
     <span style={{ gridRow: "1 / 4" }}>→</span>
-    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+    <div className="border border-gray-400 px-2 py-2 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
       Wait
     </div>
     <span style={{ gridRow: "1 / 4" }}>→</span>
-    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+    <div className="border border-gray-400 px-2 py-2 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
       Track completion
     </div>
     <span style={{ gridRow: "1" }}>↗</span>
-    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1" }}>
+    <div className="border border-gray-400 px-2 py-2 dark:border-gray-600" style={{ gridRow: "1" }}>
       Poll project
     </div>
     <span style={{ gridRow: "1" }}>↘</span>
-    <div className="border border-gray-400 px-3 py-3 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
+    <div className="border border-gray-400 px-2 py-2 dark:border-gray-600" style={{ gridRow: "1 / 4" }}>
       Download result
     </div>
 
     <span style={{ gridColumn: "8", gridRow: "3" }}>↘</span>
     <div
-      className="border border-gray-400 px-3 py-3 dark:border-gray-600"
+      className="border border-gray-400 px-2 py-2 dark:border-gray-600"
       style={{ gridColumn: "9", gridRow: "3" }}
     >
       Receive webhook

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -6,7 +6,7 @@ description: Build a complete Magic Hour integration from scratch in this hands-
 
 Every generation follows the same lifecycle:
 
-```mermaid
+<Mermaid actions={false}>
 flowchart LR
     A["Create job"] --> B["Receive project ID"]
     B --> C["Wait"]
@@ -15,7 +15,7 @@ flowchart LR
     D --> F["Receive webhook"]
     E --> G["Download result"]
     F --> G
-```
+</Mermaid>
 
 <Card
   title="Prefer an interactive browser notebook?"

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -6,12 +6,15 @@ description: Build a complete Magic Hour integration from scratch in this hands-
 
 Every generation follows the same lifecycle:
 
-```mermaid
+```mermaid actions=false
 flowchart LR
     A["Create job"] --> B["Receive project ID"]
     B --> C["Wait"]
-    C --> D["Poll or webhook"]
-    D --> E["Download result"]
+    C --> D{"Track completion"}
+    D --> E["Poll project"]
+    D --> F["Receive webhook"]
+    E --> G["Download result"]
+    F --> G
 ```
 
 <Card

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -4,15 +4,37 @@ sidebarTitle: Creating Your First Integration
 description: Build a complete Magic Hour integration from scratch in this hands-on tutorial.
 ---
 
+Every generation follows the same lifecycle:
+
+```mermaid
+flowchart LR
+    A["Create job"] --> B["Receive project ID"]
+    B --> C["Wait"]
+    C --> D{"Track completion"}
+    D --> E["Poll project"]
+    D --> F["Receive webhook"]
+    E --> G["Download result"]
+    F --> G
+```
+
+<Card
+  title="Prefer an interactive browser notebook?"
+  icon="code"
+  href="https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing"
+  openInNewTab
+>
+  Open the Google Colab cookbook and try every API without local setup.
+</Card>
+
 ## What You'll Build
 
 In this tutorial, you'll create a working application that generates an AI image using the Magic Hour API. By the end, you'll have:
 
-- ✅ A complete project structure ready for development
-- ✅ Code that creates a job, monitors its progress, and downloads the result
-- ✅ Proper file handling for inputs and outputs
-- ✅ Error handling for production use
-- ✅ A downloadable GitHub repository to reference
+- A complete project structure ready for development
+- Code that creates a job, monitors its progress, and downloads the result
+- Proper file handling for inputs and outputs
+- Error handling for production use
+- A downloadable GitHub repository to reference
 
 <Note>
   **Estimated time**: 15-20 minutes **Prerequisites**: API key from [Developer

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -6,16 +6,13 @@ description: Build a complete Magic Hour integration from scratch in this hands-
 
 Every generation follows the same lifecycle:
 
-<Mermaid actions={false}>
+```mermaid
 flowchart LR
     A["Create job"] --> B["Receive project ID"]
     B --> C["Wait"]
-    C --> D{"Track completion"}
-    D --> E["Poll project"]
-    D --> F["Receive webhook"]
-    E --> G["Download result"]
-    F --> G
-</Mermaid>
+    C --> D["Poll or webhook"]
+    D --> E["Download result"]
+```
 
 <Card
   title="Prefer an interactive browser notebook?"

--- a/integration/webhook/create-webhook.mdx
+++ b/integration/webhook/create-webhook.mdx
@@ -5,10 +5,10 @@ description: Set up and test your first webhook end-to-end to receive real-time 
 
 By the end of this guide, you'll have:
 
-- ✅ Created a webhook endpoint in your application
-- ✅ Registered it with Magic Hour
-- ✅ Tested it with a real API call
-- ✅ Verified webhook delivery works
+- Created a webhook endpoint in your application
+- Registered it with Magic Hour
+- Tested it with a real API call
+- Verified webhook delivery works
 
 ## What Are Webhooks?
 
@@ -391,7 +391,7 @@ Within seconds, you should see webhook events in your console or webhook.site:
     "status": "complete",
     "downloads": [
       {
-        "url": "https://images.magichour.ai/id/output.png",
+        "url": "https://videos.magichour.ai/id/output.png",
         "expires_at": "2024-10-19T05:16:19.027Z"
       }
     ]

--- a/integration/webhook/event-types.mdx
+++ b/integration/webhook/event-types.mdx
@@ -213,7 +213,7 @@ Image events track the lifecycle of image processing jobs. All payloads match th
     "type": "AI_IMAGE_GENERATOR",
     "downloads": [
       {
-        "url": "https://images.magichour.ai/clx8abc123def456ghi789/output.png",
+        "url": "https://videos.magichour.ai/clx8abc123def456ghi789/output.png",
         "expires_at": "2024-10-19T05:16:19.027Z"
       }
     ],

--- a/integration/webhook/overview.mdx
+++ b/integration/webhook/overview.mdx
@@ -6,10 +6,10 @@ description: Set up webhooks and test them end-to-end in under 10 minutes
 
 By the end of this guide, you'll have:
 
-- ✅ Created a webhook endpoint in your application
-- ✅ Registered it with Magic Hour
-- ✅ Tested it with a real API call
-- ✅ Verified webhook delivery works
+- Created a webhook endpoint in your application
+- Registered it with Magic Hour
+- Tested it with a real API call
+- Verified webhook delivery works
 
 ## How Webhooks Work
 
@@ -397,7 +397,7 @@ Payload: {
   "status": "complete",
   "downloads": [
     {
-      "url": "https://images.magichour.ai/id/output.png",
+      "url": "https://videos.magichour.ai/id/output.png",
       "expires_at": "2024-10-19T05:16:19.027Z"
     }
   ]
@@ -419,7 +419,7 @@ Your webhook received the download URL. Let's grab the generated image:
 import requests
 
 # Extract download URL from webhook payload
-download_url = "https://images.magichour.ai/id/output.png"
+download_url = "https://videos.magichour.ai/id/output.png"
 
 # Download the image
 response = requests.get(download_url)
@@ -431,7 +431,7 @@ print("✅ Image downloaded as generated_image.png")
 
 ```bash cURL
 # Use the URL from your webhook payload
-curl -o generated_image.png "https://images.magichour.ai/id/output.png"
+curl -o generated_image.png "https://videos.magichour.ai/id/output.png"
 echo "✅ Image downloaded as generated_image.png"
 ```
 


### PR DESCRIPTION
## Summary
- Add a simple create → wait → poll/webhook → download flowchart plus Colab cards on Quick Start and First Integration
- Drop redundant ✅ from checklist bullets
- Align image download examples to `videos.magichour.ai`

## Test plan
- [ ] Quick Start shows mermaid lifecycle + Colab card near top
- [ ] First Integration shows mermaid + Colab; checklist has no ✅
- [ ] Webhook overview/create/event-types image URLs use `videos.magichour.ai`


Made with [Cursor](https://cursor.com)