### PR TITLE
feat: compact introduction Get Started cards

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -35,7 +35,7 @@ The Magic Hour API provides programmatic access to our most popular AI tools. He
 
 If you're new to Magic Hour, start here to learn the essentials and make your first API call.
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Quick Start" icon="forward-fast" href="/get-started/quick-start">
     First request in 3 minutes.
   </Card>
@@ -50,6 +50,9 @@ If you're new to Magic Hour, start here to learn the essentials and make your fi
   >
     Try every API in the browser.
   </Card>
+  <Card title="Pricing & Billing" icon="credit-card" href="/billing/overview">
+    Costs, plans, and credit usage.
+  </Card>
   <Card title="Video Tools" icon="video" href="/tools/video-tools">
     Face swap, lip sync, animation.
   </Card>
@@ -63,8 +66,8 @@ If you're new to Magic Hour, start here to learn the essentials and make your fi
   >
     Celebrity voices and cloning.
   </Card>
-  <Card title="Pricing & Billing" icon="credit-card" href="/billing/overview">
-    Costs, plans, and credit usage.
+  <Card title="Integration Guide" icon="diagram-project" href="/integration/overview">
+    Lifecycle, polling, and webhooks.
   </Card>
 </CardGroup>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -44,14 +44,20 @@ If you're new to Magic Hour, start here to learn the essentials and make your fi
   </Card>
 </CardGroup>
 
-<CardGroup cols={1}>
+<CardGroup cols={3}>
   <Card
     title="Colab Cookbook"
     icon="code"
     href="https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing"
     openInNewTab
   >
-    Try every API in the browser — API key only, no local setup.
+    Try every API in the browser.
+  </Card>
+  <Card title="Pricing & Billing" icon="credit-card" href="/billing/overview">
+    Costs, plans, and credit usage.
+  </Card>
+  <Card title="Integration Guide" icon="diagram-project" href="/integration/overview">
+    Lifecycle, polling, and webhooks.
   </Card>
 </CardGroup>
 
@@ -70,8 +76,6 @@ If you're new to Magic Hour, start here to learn the essentials and make your fi
     Celebrity voices and cloning.
   </Card>
 </CardGroup>
-
-See also [Pricing & Billing](/billing/overview) and the [Integration Guide](/integration/overview).
 
 
 <br />

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -35,45 +35,36 @@ The Magic Hour API provides programmatic access to our most popular AI tools. He
 
 If you're new to Magic Hour, start here to learn the essentials and make your first API call.
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Quick Start" icon="forward-fast" href="/get-started/quick-start">
-    Make your first request in 3 minutes.
+    First request in 3 minutes.
   </Card>
   <Card title="API Reference" icon="webhook" href="/api-reference">
-    Complete documentation for all endpoints.
+    All endpoints in one place.
   </Card>
-</CardGroup>
-
-<CardGroup cols={1}>
   <Card
-    title="Try All APIs - Google Colab Cookbook"
+    title="Colab Cookbook"
     icon="code"
     href="https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing"
     openInNewTab
   >
-    Run sample code for all 22 APIs. Only requires an API key.
+    Try every API in the browser.
   </Card>
-</CardGroup>
-
-<CardGroup cols={3}>
   <Card title="Video Tools" icon="video" href="/tools/video-tools">
-    Face swap, lip sync, animation, and more.
+    Face swap, lip sync, animation.
   </Card>
   <Card title="Image Tools" icon="image" href="/tools/image-tools">
-    AI generation, editing, and enhancement.
+    Generation, editing, enhancement.
   </Card>
   <Card
     title="Audio Tools"
     icon="microphone"
     href="/api-reference/audio-projects/ai-voice-generator"
   >
-    AI voice generation with celebrity voices.
+    Celebrity voices and cloning.
   </Card>
-</CardGroup>
-
-<CardGroup cols={1}>
   <Card title="Pricing & Billing" icon="credit-card" href="/billing/overview">
-    Understand costs, billing options, and credit usage for all API tools.
+    Costs, plans, and credit usage.
   </Card>
 </CardGroup>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -42,17 +42,20 @@ If you're new to Magic Hour, start here to learn the essentials and make your fi
   <Card title="API Reference" icon="webhook" href="/api-reference">
     All endpoints in one place.
   </Card>
+</CardGroup>
+
+<CardGroup cols={1}>
   <Card
     title="Colab Cookbook"
     icon="code"
     href="https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing"
     openInNewTab
   >
-    Try every API in the browser.
+    Try every API in the browser — API key only, no local setup.
   </Card>
-  <Card title="Pricing & Billing" icon="credit-card" href="/billing/overview">
-    Costs, plans, and credit usage.
-  </Card>
+</CardGroup>
+
+<CardGroup cols={3}>
   <Card title="Video Tools" icon="video" href="/tools/video-tools">
     Face swap, lip sync, animation.
   </Card>
@@ -66,10 +69,10 @@ If you're new to Magic Hour, start here to learn the essentials and make your fi
   >
     Celebrity voices and cloning.
   </Card>
-  <Card title="Integration Guide" icon="diagram-project" href="/integration/overview">
-    Lifecycle, polling, and webhooks.
-  </Card>
 </CardGroup>
+
+See also [Pricing & Billing](/billing/overview) and the [Integration Guide](/integration/overview).
+
 
 <br />
 


### PR DESCRIPTION
## Summary
- Collapse four mixed-width CardGroups on the Introduction page into one 3-column grid
- Shorten card titles/descriptions so Get Started scans in one block

## Test plan
- [ ] http://localhost:3001/ — Get Started is one compact grid (Quick Start, API Reference, Colab, Video, Image, Audio, Pricing)
- [ ] All card links still resolve (Colab opens new tab)

<img width="743" height="512" alt="image" src="https://github.com/user-attachments/assets/b93a1fbc-c142-4514-818e-ce24f7c5295c" />

Made with [Cursor](https://cursor.com)