### PR TITLE
feat(eng-3240): weekly changelog auto-PR workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,62 @@
+name: Update Changelog
+
+on:
+  schedule:
+    # Run weekly on Monday at 3 AM UTC
+    - cron: "0 3 * * 1"
+  workflow_dispatch: # Allow manual trigger
+    inputs:
+      since:
+        description: "Override start date (YYYY-MM-DD). Leave blank to auto-detect from changelog.mdx."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate changelog entries
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          yarn changelog --skip-select --yes \
+            ${{ github.event.inputs.since && format('--since {0}', github.event.inputs.since) || '' }}
+
+      - name: Format with Prettier
+        run: yarn prettier --write changelog.mdx
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "chore: update changelog"
+          title: "chore: update changelog"
+          body: |
+            Automated changelog update.
+
+            New `<Update>` entries were drafted from recently completed Linear "feature" issues and tagged by surface (API / Web App).
+
+            Before merging:
+            - Review the generated copy for accuracy and tone
+            - Confirm the API / Web App tags are correct
+            - Optionally add a real screenshot via `<Frame>` (new entries ship without images by default)
+          branch: update-changelog
+          delete-branch: true


### PR DESCRIPTION
Adds a scheduled GitHub Action that drafts changelog entries and opens a review PR — automating the previously hand-maintained [docs.magichour.ai/changelog](https://docs.magichour.ai/changelog).

Second (final) PR for ENG-3240. Builds on the generator changes in #366 (merged): the `--yes` non-interactive flag and API/Web App tagging it relies on are already on `main`.

### What it does
`.github/workflows/update-changelog.yml`:
- **Triggers:** weekly cron (Mon 03:00 UTC) + manual `workflow_dispatch` (optional `since` date override).
- **Runs:** `yarn changelog --skip-select --yes` → `prettier --write changelog.mdx` → opens a `chore: update changelog` PR via `peter-evans/create-pull-request@v8`.
- **Review-only:** it never commits to the live changelog or auto-merges — a human reviews and merges the generated PR.

### Requires (ops)
Repo secrets in **Settings → Secrets → Actions**: `LINEAR_API_KEY`, `LINEAR_TEAM_ID`, `OPENAI_API_KEY`. Until set, scheduled runs fail harmlessly without touching the docs.

### Testing
After merge: **Actions → Update Changelog → Run workflow** → confirm a `chore: update changelog` PR opens with tagged, image-free entries and green `pr-checks`. (Schedule/dispatch only surface from the default branch, and fork PRs can't read secrets, so the end-to-end run happens post-merge.)