### PR TITLE
feat: add --until end date to changelog generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@clack/prompts": "1.2.0",
     "@linear/sdk": "81.0.0",
     "@mintlify/scraping": "4.0.868",
+    "@types/node": "26.1.1",
     "ai": "6.0.153",
     "dotenv": "17.4.2",
     "mintlify": "4.2.686",

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -3,20 +3,29 @@
  * Automatic changelog generator for Magic Hour docs.
  *
  * Fetches Linear issues with the "feature" label (then keeps only issues whose
- * completion calendar day in America/Los_Angeles is after the top <Update> label),
+ * completion calendar day in America/Los_Angeles falls in the since/until window),
  * rewrites each into polished MDX prose via GPT-5, and
  * prepends the new <Update> blocks to changelog.mdx.
  *
  * Each generated <Update> block is tagged "API" and/or "Web App" so readers can
  * filter the changelog by surface (Mintlify renders these tags as filter pills).
  *
+ * Date window (America/Los_Angeles calendar days):
+ *   --since omitted → start = day after top <Update label="YYYY-MM-DD"> in changelog.mdx
+ *                     (strictly after that label; issues on the label day itself are skipped)
+ *   --since set     → start = that day inclusive (LA day ≥ --since)
+ *   --until omitted → no end bound (include everything from start through now)
+ *   --until set     → end = that day inclusive (LA day ≤ --until)
+ *
  * Usage:
- *   yarn changelog                  # auto-detect last date from changelog.mdx
- *   yarn changelog --since 2026-01-01  # override start date
- *   yarn changelog --list-teams     # print available Linear team IDs and exit
- *   yarn changelog --dry-run        # print generated MDX without writing files
- *   yarn changelog --skip-select    # include all fetched issues (no multiselect prompt)
- *   yarn changelog --yes            # write without the interactive confirm prompt (for CI)
+ *   yarn changelog                       # since=day after latest <Update>; until=none
+ *   yarn changelog --since 2026-01-01    # override start (inclusive)
+ *   yarn changelog --until 2026-01-31    # optional end (inclusive)
+ *   yarn changelog --since 2026-01-01 --until 2026-01-31
+ *   yarn changelog --list-teams          # print available Linear team IDs and exit
+ *   yarn changelog --dry-run             # print generated MDX without writing files
+ *   yarn changelog --skip-select         # include all fetched issues (no multiselect prompt)
+ *   yarn changelog --yes                 # write without the interactive confirm prompt (for CI)
  *
  * CI: .github/workflows/update-changelog.yml runs this on a schedule with
  * --skip-select --yes and opens a PR with the new entries.
@@ -95,6 +104,8 @@ const skipSelect = args.includes("--skip-select");
 const autoYes = args.includes("--yes");
 const sinceIdx = args.indexOf("--since");
 const sinceOverride = sinceIdx !== -1 ? args[sinceIdx + 1] : undefined;
+const untilIdx = args.indexOf("--until");
+const untilOverride = untilIdx !== -1 ? args[untilIdx + 1] : undefined;
 
 // ---------------------------------------------------------------------------
 // Env validation
@@ -146,13 +157,21 @@ interface LinearIssue {
 async function fetchFeatureIssues(
   client: LinearClient,
   teamId: string,
-  completedOnOrAfterUtc: Date
+  completedOnOrAfterUtc: Date,
+  completedOnOrBeforeUtc?: Date
 ): Promise<LinearIssue[]> {
+  const completedAtFilter: { gte: string; lte?: string } = {
+    gte: completedOnOrAfterUtc.toISOString(),
+  };
+  if (completedOnOrBeforeUtc) {
+    completedAtFilter.lte = completedOnOrBeforeUtc.toISOString();
+  }
+
   const issueConnection = await client.issues({
     filter: {
       team: { id: { eq: teamId } },
       labels: { name: { eq: LABEL_NAME } },
-      completedAt: { gte: completedOnOrAfterUtc.toISOString() },
+      completedAt: completedAtFilter,
     },
     // Fetch up to 100 issues; pagination not expected to be needed
     first: 100,
@@ -350,7 +369,7 @@ async function main(): Promise<void> {
 
   const teamId = requireEnv("LINEAR_TEAM_ID");
 
-  // Loose UTC bound for Linear; real cutoff matches <Update> labels via toDateStr (LA).
+  // Loose UTC bounds for Linear; real cutoffs match <Update> labels via toDateStr (LA).
   let completedOnOrAfterUtc: Date;
   let changelogDayOk: (issue: LinearIssue) => boolean;
   if (sinceOverride) {
@@ -364,10 +383,27 @@ async function main(): Promise<void> {
     console.log(`Last changelog <Update>: ${lastLabel}`);
   }
 
+  let completedOnOrBeforeUtc: Date | undefined;
+  if (untilOverride) {
+    completedOnOrBeforeUtc = new Date(`${untilOverride}T23:59:59.999Z`);
+    const dayOk = changelogDayOk;
+    changelogDayOk = (i) => dayOk(i) && toDateStr(i.completedAt) <= untilOverride;
+    console.log(`Using --until ${untilOverride} (LA calendar day ≤ this after fetch)`);
+  }
+
   console.log(
-    `\nFetching Linear issues with label "${LABEL_NAME}" completed on or after ${completedOnOrAfterUtc.toISOString()} (UTC)...`
+    `\nFetching Linear issues with label "${LABEL_NAME}" completed on or after ${completedOnOrAfterUtc.toISOString()} (UTC)` +
+      (completedOnOrBeforeUtc
+        ? ` and on or before ${completedOnOrBeforeUtc.toISOString()} (UTC)`
+        : "") +
+      "..."
   );
-  const raw = await fetchFeatureIssues(client, teamId, completedOnOrAfterUtc);
+  const raw = await fetchFeatureIssues(
+    client,
+    teamId,
+    completedOnOrAfterUtc,
+    completedOnOrBeforeUtc
+  );
   const issues = raw.filter(changelogDayOk);
 
   if (issues.length === 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,6 +2051,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:26.1.1":
+  version: 26.1.1
+  resolution: "@types/node@npm:26.1.1"
+  dependencies:
+    undici-types: "npm:~8.3.0"
+  checksum: 10/df6555a94c6b4cf74e6238373e2881e72dc91058cf2ba173be77ea3974aaa8f459c2f10fbb7eb644fb1e5189dd8407097f5d39506fad39c89bde18acb3b90316
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:*, @types/unist@npm:^3.0.0":
   version: 3.0.3
   resolution: "@types/unist@npm:3.0.3"
@@ -3447,6 +3456,7 @@ __metadata:
     "@clack/prompts": "npm:1.2.0"
     "@linear/sdk": "npm:81.0.0"
     "@mintlify/scraping": "npm:4.0.868"
+    "@types/node": "npm:26.1.1"
     ai: "npm:6.0.153"
     dotenv: "npm:17.4.2"
     mintlify: "npm:4.2.686"
@@ -9579,6 +9589,13 @@ __metadata:
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10/583ac7bbf4ff69931d3985f4762cde2690bb607844c16a5e2fbb92ed312fe4fa1b365e953032d469fa28ba8b224e88a595f0b10a449332f83fa77c695e567dbe
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10/6681d2837ac75a75ac1cc46090aa2b8ddc7c6b8ecc295a6cdb06838752a730da3d8afeecf05e5ab7903160eafad3a8b6ffa1927e5ded260590f4d4fef18646d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Add `--until YYYY-MM-DD` to `yarn changelog` so we can isolate sections of changelog to add 
