### PR TITLE
feat: skip A/B testing issues in changelog generation

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -49,12 +49,6 @@ Characters still use the existing image workflow, directing users to the Charact
 
 We’re testing GPT Image 2 as the default model for paid users in the AI Image Generator and AI Image Editor.
 
-## Contextual Upgrade Prompt After Your First Generation
-
-After completing their first image, video, or audio generation in the dashboard, users now see a contextual prompt tailored to the type of content they created.
-
-The prompt highlights the benefits of upgrading and includes a **View Plans** button. Users can review subscription tiers by default or switch to credit packs.
-
 </Update>
 
 <Update label="2026-07-16" tags={["API","Web App"]}>
@@ -357,10 +351,6 @@ Compare monthly and yearly billing, review your estimated coverage or shortfall,
 <Update label="2026-06-24" tags={["Web App"]}>
 {/*linear:ENG-3503,ENG-3501,ENG-3499,ENG-3513*/}
 
-## Improved “Create or edit images” Entry Point
-
-We’re testing the best destination for the “Create or edit images” option, directing users to either AI Image Editor or AI Image Generator based on the experience being evaluated.
-
 ## Choose Photo or Video for Lip Sync and Talking Photo
 
 Lip Sync and Talking Photo now include a photo/video toggle, making it easier to choose the right input type before getting started.
@@ -493,10 +483,6 @@ You can now run multiple web app generations at the same time, based on your pla
 
 If you reach your limit, we’ll show an upgrade prompt explaining how to run more generations simultaneously. Concurrency limits apply to web app generations only—API usage does not count toward this limit.
 
-## Signup Prompt Added After Your First Image-to-Video Generation
-
-We’ve added a signup upsell to the free Image to Video tool after your first generation. This gives you a clear next step to continue with Magic Hour after seeing your result, while we test and improve the onboarding experience.
-
 </Update>
 
 <Update label="2026-06-06" tags={["Web App"]}>
@@ -534,12 +520,6 @@ You can also control the output resolution by setting a maximum resolution or pr
 
 <Update label="2026-06-02" tags={["Web App"]}>
 {/*linear:ENG-3063,ENG-3207,ENG-3188,ENG-2965*/}
-
-## Earn Credits Through New Incentives
-
-We’ve added a new credit incentive program, accessible by clicking the credit icon or credit balance in the dashboard. Free users and subscribers can now view available ways to earn credits and redeem rewards.
-
-The program is designed to encourage meaningful product engagement while keeping credit rewards capped.
 
 ## GPT Image 2 Is Now Available
 
@@ -626,17 +606,13 @@ Try it out now: https://magichour.ai/products/ai-video-expander
 <Update label="2026-05-27" tags={["API","Web App"]}>
 {/*linear:ENG-3027,ENG-3082,ENG-2908*/}
 
-## Talking Photo V5 Enables Multi-Minute Generations
+## Talking Photo Enables Multi-Minute Generations
 
-Talking Photo V5 now supports multi-minute video generations, making it possible to create substantially longer talking photo videos.
+Talking Photo now supports multi-minute video generations, making it possible to create substantially longer talking photo videos.
 
 ## Remove Watermarks from Face Swap Videos
 
 Free face swap video outputs now include a **Remove watermark** option in the dashboard. Users can view subscription options from the output and, after subscribing, have the watermark removed from their existing video without regenerating it.
-
-## New Onboarding Flow
-
-We launched onboarding flow v2 with additional steps designed to improve activation and conversion. The new experience can also be A/B tested against the current onboarding flow.
 
 </Update>
 

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -21,6 +21,10 @@
  * Issues whose identifiers already appear in changelog.mdx are skipped
  * (covers --since overlap + re-runs).
  *
+ * A/B tests: issues whose title/description look like experiments (A/B test,
+ * "We're testing…", title starting with "Testing", GrowthBook, etc.) are dropped
+ * automatically so internal experiments do not land in the public changelog.
+ *
  * Usage:
  *   yarn changelog                       # since=day after latest <Update>; until=none
  *   yarn changelog --since 2026-01-01    # override start (inclusive)
@@ -212,6 +216,25 @@ async function fetchFeatureIssues(
   issues.sort((a, b) => a.completedAt.getTime() - b.completedAt.getTime());
 
   return issues;
+}
+
+/**
+ * Drop internal A/B / experiment tickets from the public changelog.
+ * Prefer specific experiment phrasing over bare "testing" (avoids "same in testing").
+ */
+const AB_TESTING_PATTERNS: RegExp[] = [
+  /\ba\s*\/\s*b\b/i, // A/B
+  /\bab[\s_-]?tests?\b/i, // ab test, ab-test
+  /\bsplit[\s_-]?tests?\b/i,
+  /\bgrowthbook\b/i,
+  /\bexperiments?\b/i, // "this experiment", not "experimental"
+  /\b(?:we(?:['’]re| are)|while we)\s+test(?:ing)?\b/i,
+  /^testing\b/i, // title like "Testing GPT Image 2 as the Default…"
+];
+
+function isAbTestingIssue(issue: LinearIssue): boolean {
+  const haystack = `${issue.title}\n${issue.description ?? ""}`;
+  return AB_TESTING_PATTERNS.some((re) => re.test(haystack));
 }
 
 // ---------------------------------------------------------------------------
@@ -428,12 +451,25 @@ async function main(): Promise<void> {
   const changelogContent = fs.readFileSync(CHANGELOG_PATH, "utf-8");
   const knownLinearIds = parseKnownLinearIds(changelogContent);
   const inWindow = raw.filter(changelogDayOk);
-  const issues = inWindow.filter((i) => !knownLinearIds.has(i.identifier));
-  const skippedKnown = inWindow.length - issues.length;
+  const notYetWritten = inWindow.filter((i) => !knownLinearIds.has(i.identifier));
+  const skippedKnown = inWindow.length - notYetWritten.length;
   if (skippedKnown > 0) {
     console.log(
       `Skipping ${skippedKnown} issue(s) already marked in changelog.mdx (${knownLinearIds.size} known identifier(s)).`
     );
+  }
+
+  const abTesting: LinearIssue[] = [];
+  const issues: LinearIssue[] = [];
+  for (const issue of notYetWritten) {
+    if (isAbTestingIssue(issue)) abTesting.push(issue);
+    else issues.push(issue);
+  }
+  if (abTesting.length > 0) {
+    console.log(`Skipping ${abTesting.length} A/B testing / experiment issue(s):`);
+    for (const issue of abTesting) {
+      console.log(`  [${toDateStr(issue.completedAt)}] ${issue.identifier} ${issue.title}`);
+    }
   }
 
   if (issues.length === 0) {


### PR DESCRIPTION
## Summary
- Auto-skip Linear issues whose title/description match A/B / experiment patterns (`A/B`, `ab-test`, `GrowthBook`, `we're testing`, titles starting with `Testing`, etc.)
- Remove existing public changelog entries for experiments, upsells, and related internal growth work

## Test plan
- [ ] Run `yarn changelog --dry-run --since <date>` and confirm A/B-style issues are logged as skipped
- [ ] Confirm kept product entries still generate normally
- [ ] Spot-check removed sections in `changelog.mdx`

Made with [Cursor](https://cursor.com)