### PR TITLE
fix: quote changelog year titles for Mintlify

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -1,5 +1,5 @@
 ---
-title: 2026
+title: "2026"
 description: Latest feature enhancements in Magic Hour
 rss: true
 ---

--- a/changelog/2023.mdx
+++ b/changelog/2023.mdx
@@ -1,5 +1,5 @@
 ---
-title: 2023
+title: "2023"
 description: List of feature releases in 2023
 ---
 

--- a/changelog/2024.mdx
+++ b/changelog/2024.mdx
@@ -1,5 +1,5 @@
 ---
-title: 2024
+title: "2024"
 description: List of feature releases in 2024
 ---
 

--- a/changelog/2025.mdx
+++ b/changelog/2025.mdx
@@ -1,5 +1,5 @@
 ---
-title: 2025
+title: "2025"
 description: Latest feature enhancements in Magic Hour
 rss: true
 ---


### PR DESCRIPTION
## Summary
- Quote changelog frontmatter titles (`"2023"`–`"2026"`) so YAML keeps them as strings
- Fixes local Mintlify crash: `TypeError: L.trim is not a function` on changelog pages

## Test plan
- [ ] `yarn dev` and open `/changelog` — page renders, no `trim` console error
- [ ] Spot-check `/changelog/2025` (and older years if linked) similarly


Made with [Cursor](https://cursor.com)