### PR TITLE
fix: correct pricing, stale params, and broken examples across docs

### DIFF
--- a/billing/resolution-limits.mdx
+++ b/billing/resolution-limits.mdx
@@ -35,8 +35,8 @@ For compute-intensive video APIs:
   - AI Headshot Generator: 1344px maximum dimension
   - AI Clothes Changer: 1472px maximum dimension
   - AI Talking Photo: 720p (1280x720)
-  - Text to Video: 1080p (1920x1080)
-  - Image to Video: 1080p (1920x1080)
+  - Text to Video: up to 4k (model-dependent; e.g. `kling-3.0` supports 4k)
+  - Image to Video: up to 4k (model-dependent; e.g. `kling-3.0` supports 4k)
   - Video to Video: 1472px maximum dimension
   - Animation: 1472px maximum dimension
 
@@ -150,8 +150,8 @@ These APIs have maximum resolution limits regardless of subscription tier:
 **Video APIs:**
 
 - **AI Talking Photo** - Maximum 720p (1280x720) across all tiers
-- **Text to Video (T2V)** - Maximum 1080p (1920x1080) across all tiers
-- **Image to Video (I2V)** - Maximum 1080p (1920x1080) across all tiers
+- **Text to Video (T2V)** - Up to 4k depending on the model (`kling-3.0` supports 4k; most models cap at 1080p)
+- **Image to Video (I2V)** - Up to 4k depending on the model (`kling-3.0` supports 4k; most models cap at 1080p)
 - **Video to Video** - Maximum 1472px across all tiers
 - **Animation** - Maximum 1472px across all tiers
 

--- a/billing/usage-based-pricing.mdx
+++ b/billing/usage-based-pricing.mdx
@@ -30,7 +30,7 @@ description: Pay only for what you use with automatic monthly billing and volume
 | Pay after you use          | Pay upfront                |
 | Automatic monthly billing  | Manual credit purchases    |
 | Volume discounts included  | Fixed credit amounts       |
-| No unused credits          | Credits can expire unused  |
+| No unused credits          | Prepaid credits never expire |
 | Perfect for variable usage | Good for predictable usage |
 
 ## Choose Your Tier
@@ -45,7 +45,7 @@ import { PricingCard } from "/snippets/pricing-card.mdx";
   title="Starter"
   prices={[{ amount: "0.90", label: "/ 1000 credits" }]}
   benefits={[
-    "512x512 resolution",
+    "576x576 resolution",
     "Access to all image modes",
     "Access to Animation, Face Swap, Lip Sync, Subtitle Generator, Talking Photo",
   ]}

--- a/docs.json
+++ b/docs.json
@@ -57,6 +57,10 @@
     {
       "source": "/tools/audio-apis",
       "destination": "/tools/audio-tools"
+    },
+    {
+      "source": "/api-reference/image-projects/ai-photo-editor",
+      "destination": "/api-reference/image-projects/ai-image-editor"
     }
   ],
   "navigation": {
@@ -87,6 +91,7 @@
                   "integration/webhook/overview",
                   "integration/webhook/create-webhook",
                   "integration/webhook/secure-handler",
+                  "integration/webhook/create-handler",
                   "integration/webhook/event-types"
                 ]
               },

--- a/get-started/authentication.mdx
+++ b/get-started/authentication.mdx
@@ -70,7 +70,7 @@ In the Developer Hub, you can see all your API keys with:
 - **Last 4 Characters**: The last 4 characters of the key
 - **Created**: When the key was created
 
-![API Keys list](./images/copy-and-store-api-key.jpg)
+![API Keys list](./images/managing-your-api-keys.jpg)
 
 ### Revoking API Keys
 
@@ -241,7 +241,7 @@ This helps you:
   href="https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing"
   openInNewTab
 >
-  Try all 22 APIs with sample code. Just add your API key.
+  Try the Magic Hour APIs with ready-to-run sample code. Just add your API key.
 </Card>
 
 <Card title="SDKs" icon="code" href="/integration/adding-api-to-your-app">

--- a/get-started/cookbook.mdx
+++ b/get-started/cookbook.mdx
@@ -1,11 +1,11 @@
 ---
 title: "API Cookbook - Google Colab"
-description: "Try all 22 Magic Hour APIs with ready-to-run sample code."
+description: "Try the Magic Hour APIs with ready-to-run sample code."
 ---
 
 ## Overview
 
-The Magic Hour API Cookbook is a comprehensive Google Colab notebook containing working examples for all 22 APIs. Simply add your API key and start experimenting with:
+The Magic Hour API Cookbook is a comprehensive Google Colab notebook containing working examples for the most popular Magic Hour APIs. Simply add your API key and start experimenting with:
 
 - All video tools (Animation, Face Swap, Lip Sync, etc.)
 - All image tools (Image Generator, Face Editor, Upscaler, etc.)
@@ -24,7 +24,7 @@ The Magic Hour API Cookbook is a comprehensive Google Colab notebook containing 
 
 The cookbook includes:
 
-- **Working code samples** for all 22 APIs
+- **Working code samples** for the most popular APIs
 - **Pre-configured parameters** optimized for fast execution
 - **Error handling** examples
 - **Best practices** and tips

--- a/get-started/quick-start.mdx
+++ b/get-started/quick-start.mdx
@@ -30,7 +30,7 @@ Magic Hour is an AI video and image generation platform. You submit a job, we re
 
 **Why:** API keys authenticate your requests and track your usage.
 
-1. Open the [API Keys section of the Developer Hub](https://magichour.ai/developer?tab=api-keys) and sign in.
+1. Open the [API Keys section of the Developer Hub](https://magichour.ai/developer?tab=api-keys&ref=docs-quickstart) and sign in.
 2. Click **Create key**, give it a name (e.g., "My First Project"), and create it.
 3. **Copy the API key immediately** — you won't be able to see it again.
 
@@ -91,7 +91,7 @@ cd magic-hour-quickstart
 npm init -y
 
 # Enable ES module support (required for the SDK)
-echo '{"type":"module"}' > package.json
+npm pkg set type=module
 
 # Create your JavaScript file
 touch main.js
@@ -136,7 +136,7 @@ result. Choose the example that matches what you want to build:
 
 | Example             | Best for                  | Typical cost                     | Typical wait  |
 | :------------------ | :------------------------ | :------------------------------- | :------------ |
-| **Generate image**  | Cheapest first success    | 5 credits                        | 30-60 seconds |
+| **Generate image**  | Cheapest first success    | 5 credits                        | 5-30 seconds  |
 | **Face swap video** | Our most popular API path | ~200 credits for the sample clip | 2-5 minutes   |
 
 ### Copy the code and run it
@@ -261,7 +261,7 @@ func main() {
 			fmt.Println(err)
 			return
 		}
-		if res.Status == "complete" {
+        if res.Status == "complete" {
 			println("render complete!")
 			url := res.Downloads[0].Url
 			outputFile := "output.png"
@@ -338,7 +338,7 @@ async fn main() {
             .await
             .unwrap();
         match res.status {
-            magic_hour::models::GetV1ImageProjectsIdResponseStatusEnum::Complete => {
+            magic_hour::models::V1ImageProjectsGetResponseStatusEnum::Complete => {
                 println!("render complete!");
                 let url = res.downloads[0].url.clone();
 
@@ -356,7 +356,7 @@ async fn main() {
 
                 return;
             }
-            magic_hour::models::GetV1ImageProjectsIdResponseStatusEnum::Error => {
+            magic_hour::models::V1ImageProjectsGetResponseStatusEnum::Error => {
                 println!("render failed");
                 return;
             }
@@ -525,15 +525,13 @@ func main() {
 	client := sdk.NewClient(sdk.WithBearerAuth(os.Getenv("MAGIC_HOUR_API_KEY")))
 	createRes, err := client.V1.FaceSwap.Create(face_swap.CreateRequest{
 		Name: nullable.NewValue("Swap Tom Cruise into Iron Man scene"),
-		Assets: types.PostV1FaceSwapBodyAssets{
+		Assets: types.V1FaceSwapCreateBodyAssets{
 			ImageFilePath: "https://videos.magichour.ai/api-assets/sample/tom-cruise.png",
 			VideoFilePath: nullable.NewValue("https://videos.magichour.ai/api-assets/sample/iron-man.mp4"),
-			VideoSource:   types.PostV1FaceSwapBodyAssetsVideoSourceEnumFile,
+			VideoSource:   types.V1FaceSwapCreateBodyAssetsVideoSourceEnumFile,
 		},
 		StartSeconds: 2.3,
 		EndSeconds:   8.5,
-		Height:       288,
-		Width:        512,
 	})
 	if err != nil {
 		fmt.Println(err)
@@ -601,19 +599,17 @@ async fn main() {
         .face_swap()
         .create(magic_hour::resources::v1::face_swap::CreateRequest {
             name: Some("Swap Tom Cruise into Iron Man scene".to_string()),
-            assets: magic_hour::models::PostV1FaceSwapBodyAssets {
+            assets: magic_hour::models::V1FaceSwapCreateBodyAssets {
                 image_file_path: "https://videos.magichour.ai/api-assets/sample/tom-cruise.png"
                     .to_string(),
                 video_file_path: Some(
                     "https://videos.magichour.ai/api-assets/sample/iron-man.mp4".to_string(),
                 ),
-                video_source: magic_hour::models::PostV1FaceSwapBodyAssetsVideoSourceEnum::File,
+                video_source: magic_hour::models::V1FaceSwapCreateBodyAssetsVideoSourceEnum::File,
                 ..Default::default()
             },
             start_seconds: 2.3,
             end_seconds: 8.5,
-            height: 288,
-            width: 512,
             ..Default::default()
         })
         .await
@@ -632,7 +628,7 @@ async fn main() {
             .await
             .unwrap();
         match res.status {
-            magic_hour::models::GetV1VideoProjectsIdResponseStatusEnum::Complete => {
+            magic_hour::models::V1VideoProjectsGetResponseStatusEnum::Complete => {
                 println!(
                     "render complete! Final credit charged is {}, actual fps is {}",
                     res.credits_charged, res.fps
@@ -653,7 +649,7 @@ async fn main() {
 
                 return;
             }
-            magic_hour::models::GetV1VideoProjectsIdResponseStatusEnum::Error => {
+            magic_hour::models::V1VideoProjectsGetResponseStatusEnum::Error => {
                 println!("render failed");
                 return;
             }
@@ -688,9 +684,7 @@ create_response=$(curl -s $URL \
         "video_source": "file"
     },
     "start_seconds": 2.3,
-    "end_seconds": 8.5,
-    "height": 288,
-    "width": 512
+    "end_seconds": 8.5
   }')
 
 project_id=$(echo $create_response | jq -r '.id')
@@ -798,11 +792,13 @@ If you encounter HTTP errors, here's what they mean:
 
 | Error Code | Meaning               | Solution                                                                          |
 | :--------- | :-------------------- | :-------------------------------------------------------------------------------- |
-| `400`      | Bad Request           | Check your request parameters and format                                          |
-| `401`      | Unauthorized          | Verify your API key is correct and active                                         |
+| `400`      | Bad Request           | The response `message` names the invalid or missing field - fix it and resubmit   |
+| `401`      | Unauthorized          | Verify your API key is correct and sent as `Authorization: Bearer <key>`          |
 | `402`      | Payment Required      | Insufficient credits - [add more credits](https://magichour.ai/dashboard/my-plan) |
+| `403`      | Forbidden             | Your key is valid but the model, resolution, or feature is not available on your plan |
+| `429`      | Too Many Requests     | You are sending requests too quickly - retry with exponential backoff             |
 | `500`      | Internal Server Error | Temporary server issue - retry after a few seconds                                |
-| `502`      | Bad Gateway           | Server temporarily unavailable - retry after 30-60 seconds                        |
+| `502`      | Bad Gateway           | Server temporarily unavailable - retry after 30-60 seconds. If it failed before returning a project `id`, no job was created - resubmit |
 | `503`      | Service Unavailable   | Server overloaded - retry with exponential backoff                                |
 
 **For persistent errors:** Contact [support@magichour.ai](mailto:support@magichour.ai) with your project ID.
@@ -811,12 +807,12 @@ If you encounter HTTP errors, here's what they mean:
 
 ## Next Steps
 
-- **Explore the API Reference:** Learn how to generate and edit videos and images programmatically. [API Reference →](https://docs.magichour.ai/api-reference/files/generate-asset-upload-urls)
+- **Explore the API Reference:** Learn how to generate and edit videos and images programmatically. [API Reference →](/api-reference/overview)
 
 - **Explore Face Swap Video:** See parameter details, pricing, and production patterns in the
   [Face Swap Video guide](/tools/video/face-swap-video).
 
-- **Try All APIs in Google Colab:** [Run our complete cookbook](https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing) with sample code for all 22 APIs. Just add your API key and start experimenting.
+- **Try All APIs in Google Colab:** [Run our complete cookbook](https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing) with ready-to-run sample code. Just add your API key and start experimenting.
 
 - **Use the Web App:** Try more tools and experiment interactively at [magichour.ai](https://magichour.ai).
 

--- a/integration/adding-api-to-your-app.mdx
+++ b/integration/adding-api-to-your-app.mdx
@@ -456,9 +456,9 @@ The simplest approach is to pass file URLs:
 
 **Supported formats:**
 
-- **Images**: PNG, JPG, JPEG, HEIC, HEIF, WEBP, AVIF, JP2, TIFF, BMP
+- **Images**: PNG, JPG, JPEG, JFIF, HEIC, HEIF, WEBP, AVIF, JP2, TIFF, TIF, BMP
 - **Videos**: MP4, M4V, MOV, WEBM
-- **Audio**: MP3, WAV, AAC, FLAC, WEBM, M4A, OPUS, OGG, AIFF, AMR
+- **Audio**: MP3, WAV, AAC, FLAC, WEBM, WEBA, M4A, OPUS, OGG, OGA, AIFF, AMR
 
 See [Handling Inputs and Outputs](/integration/inputs-and-outputs#supported-file-formats) for the
 canonical format list and special-case support.
@@ -606,55 +606,58 @@ Periodically check job status. Best for:
 ```python Python SDK
 import time
 
-def wait_for_completion(client, project_id, project_type="video"):
-    """Smart polling with exponential backoff"""
+def wait_for_completion(client, project_id, project_type="video", timeout_seconds=1800):
+    """Poll with exponential backoff (3s -> 30s max) and a hard timeout."""
 
     get_method = (client.v1.video_projects.get if project_type == "video"
                  else client.v1.image_projects.get)
 
-    while True:
-        try:
-            res = get_method(id=project_id)
-            print(f"Status: {res.status}")
+    deadline = time.monotonic() + timeout_seconds
+    delay = 3.0
+    while time.monotonic() < deadline:
+        res = get_method(id=project_id)
+        print(f"Status: {res.status}")
 
-            if res.status == "complete":
-                return res  # Success!
-            elif res.status == "error":
-                raise Exception(f"Job failed: {res.error}")
-            time.sleep(3)
-        except Exception as e:
-            print(f"Error checking status: {e}")
+        if res.status == "complete":
+            return res  # Success!
+        if res.status in ("error", "canceled"):
+            raise RuntimeError(f"Job {res.status}: {res.error}")
 
-    raise TimeoutError("Job did not complete within timeout")
+        time.sleep(delay)
+        delay = min(delay * 1.5, 30.0)  # back off up to 30s between checks
+
+    raise TimeoutError(f"Job did not complete within {timeout_seconds}s")
 ```
 
 ```typescript Node SDK
 async function waitForCompletion(
   client: Client,
   projectId: string,
-  projectType: "video" | "image" = "video"
+  projectType: "video" | "image" = "video",
+  timeoutMs = 30 * 60 * 1000
 ) {
-  const getMethod =
-    projectType === "video" ? client.v1.videoProjects.get : client.v1.imageProjects.get;
+  const deadline = Date.now() + timeoutMs;
+  let delay = 3000;
 
-  while (true) {
-    try {
-      const res = await getMethod({ id: projectId });
-      console.log(`Status: ${res.status}`);
+  while (Date.now() < deadline) {
+    const res =
+      projectType === "video"
+        ? await client.v1.videoProjects.get({ id: projectId })
+        : await client.v1.imageProjects.get({ id: projectId });
+    console.log(`Status: ${res.status}`);
 
-      if (res.status === "complete") {
-        return res; // Success!
-      } else if (res.status === "error") {
-        throw new Error(`Job failed: ${res.error}`);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-    } catch (error) {
-      console.log(`Error checking status: ${error}`);
+    if (res.status === "complete") {
+      return res; // Success!
     }
+    if (res.status === "error" || res.status === "canceled") {
+      throw new Error(`Job ${res.status}: ${JSON.stringify(res.error)}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    delay = Math.min(delay * 1.5, 30_000); // back off up to 30s between checks
   }
 
-  throw new Error("Job did not complete within timeout");
+  throw new Error(`Job did not complete within ${timeoutMs}ms`);
 }
 ```
 
@@ -814,7 +817,7 @@ from magic_hour.environment import Environment
 
 # Use mock server for development
 client = Client(
-    token="API_TOKEN",
+    token="YOUR_API_KEY",  # Can use any value for mock mode
     environment=Environment.MOCK_SERVER
 )
 
@@ -827,7 +830,7 @@ import Client, { Environment } from "magic-hour";
 
 // Use mock server for development
 const client = new Client({
-  token: "API_TOKEN",
+  token: "YOUR_API_KEY", // Can use any value for mock mode
   environment: Environment.MockServer,
 });
 
@@ -873,7 +876,7 @@ Notes:
     href="https://colab.research.google.com/drive/1NTHL_lr_s-qBJ-mSecSXPzRLi9_V5JiU?usp=sharing"
     openInNewTab
   >
-    Try all 22 APIs with ready-to-run examples
+    Try the Magic Hour APIs with ready-to-run examples
   </Card>
   <Card title="File Management" icon="file" href="/integration/inputs-and-outputs">
     Advanced file upload and management techniques

--- a/integration/development-and-testing.mdx
+++ b/integration/development-and-testing.mdx
@@ -93,7 +93,8 @@ from magic_hour import Client
 from magic_hour.environment import Environment
 
 # Switch environments based on ENV variable
-env = Environment.MOCK_SERVER if os.getenv("ENV") == "development" else Environment.PRODUCTION
+# Environment.ENVIRONMENT is the production API (https://api.magichour.ai)
+env = Environment.MOCK_SERVER if os.getenv("ENV") == "development" else Environment.ENVIRONMENT
 
 client = Client(
     token=os.getenv("MAGIC_HOUR_API_KEY"),
@@ -105,8 +106,9 @@ client = Client(
 import Client, { Environment } from "magic-hour";
 
 // Switch environments based on NODE_ENV
+// Environment.Environment is the production API (https://api.magichour.ai)
 const environment =
-  process.env.NODE_ENV === "development" ? Environment.MockServer : Environment.Production;
+  process.env.NODE_ENV === "development" ? Environment.MockServer : Environment.Environment;
 
 const client = new Client({
   token: process.env.MAGIC_HOUR_API_KEY,
@@ -436,20 +438,20 @@ ENV=development python main.py  # Uses mock server
 - Build integration logic
 - Test error handling
 
-**Phase 2: Staging Testing**
+**Phase 2: Real-API Testing**
 
 ```bash
-ENV=staging python main.py  # Uses real API with test key
+python main.py  # Any ENV value other than "development" uses the real API
 ```
 
-- Test with real API using minimal credits
+- Test with the real API using minimal credits (smallest resolution and duration)
 - Validate end-to-end workflow
 - Test error scenarios
 
 **Phase 3: Production**
 
 ```bash
-ENV=production python main.py  # Uses production API key
+python main.py  # Uses your production API key
 ```
 
 - Deploy with production credentials

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -74,7 +74,7 @@ In this tutorial, you'll create a working application that generates an AI image
 
 <Note>
   **Estimated time**: 15-20 minutes **Prerequisites**: API key from [Developer
-  Hub](https://magichour.ai/developer), Python 3.8+ or Node.js 16+ installed
+  Hub](https://magichour.ai/developer?tab=api-keys), Python 3.8+ or Node.js 16+ installed
 </Note>
 
 ## Choose Your Language
@@ -174,7 +174,7 @@ def main():
     try:
         create_response = client.v1.ai_image_generator.create(
             image_count=1,
-            orientation="landscape",
+            aspect_ratio="16:9",
             style={
                 "prompt": "A serene mountain landscape at sunset with vibrant colors",
                 "tool": "ai-anime-generator"
@@ -410,7 +410,7 @@ async function main() {
 
     const createResponse = await client.v1.aiImageGenerator.create({
       imageCount: 1,
-      orientation: "landscape",
+      aspectRatio: "16:9",
       style: {
         prompt: "A serene mountain landscape at sunset with vibrant colors",
         tool: "ai-anime-generator",
@@ -526,7 +526,7 @@ Add `"type": "module"` to your `package.json` to enable ES modules:
   "main": "index.js",
   "dependencies": {
     "dotenv": "^16.0.0",
-    "magic-hour": "^0.42.0"
+    "magic-hour": "^0.70.0"
   }
 }
 ```
@@ -595,7 +595,7 @@ The SDK also provides a `generate()` function that handles polling and downloadi
 # All-in-one generate function
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="landscape",
+    aspect_ratio="16:9",
     style={
         "prompt": "A serene mountain landscape at sunset",
         "tool": "ai-anime-generator"
@@ -613,7 +613,7 @@ print(f"✅ Complete! Files: {result.downloaded_paths}")
 // All-in-one generate function
 const result = await client.v1.aiImageGenerator.generate({
   imageCount: 1,
-  orientation: "landscape",
+  aspectRatio: "16:9",
   style: {
     prompt: "A serene mountain landscape at sunset",
     tool: "ai-anime-generator",

--- a/integration/inputs-and-outputs.mdx
+++ b/integration/inputs-and-outputs.mdx
@@ -189,12 +189,12 @@ import (
 )
 
 func main() {
-	client := sdk.NewClient(sdk.WithBearerAuth(os.Getenv("API_KEY")))
+	client := sdk.NewClient(sdk.WithBearerAuth(os.Getenv("MAGIC_HOUR_API_KEY")))
 
 	// Step 1: Request upload URL
 	response, err := client.V1.Files.UploadUrls.Create(upload_urls.CreateRequest{
-		Items: []types.PostV1FilesUploadUrlsBodyItemsItem{
-			{Extension: "mp4", Type: types.PostV1FilesUploadUrlsBodyItemsItemTypeEnumVideo},
+		Items: []types.V1FilesUploadUrlsCreateBodyItemsItem{
+			{Extension: "mp4", Type: types.V1FilesUploadUrlsCreateBodyItemsItemTypeEnumVideo},
 		},
 	})
 
@@ -237,15 +237,15 @@ func main() {
 use magic_hour;
 
 let mut client = magic_hour::Client::default()
-    .with_bearer_auth(&std::env::var("API_KEY").expect("API_KEY must be set"));
+    .with_bearer_auth(&std::env::var("MAGIC_HOUR_API_KEY").expect("MAGIC_HOUR_API_KEY must be set"));
 
 // Step 1: Request upload URL
 let response = client.v1().files().upload_urls()
     .create(magic_hour::resources::v1::files::upload_urls::CreateRequest {
         items: vec![
-            magic_hour::models::PostV1FilesUploadUrlsBodyItemsItem {
+            magic_hour::models::V1FilesUploadUrlsCreateBodyItemsItem {
                 extension: "mp4".to_string(),
-                type_field: magic_hour::models::PostV1FilesUploadUrlsBodyItemsItemTypeEnum::Video
+                type_field: magic_hour::models::V1FilesUploadUrlsCreateBodyItemsItemTypeEnum::Video
             }
         ],
     }).await;
@@ -569,10 +569,10 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
     mp4, m4v, mov, webm
   </Card>
   <Card title="Image" icon="image">
-    png, jpg, jpeg, heic, heif, webp, avif, jp2, tiff, bmp
+    png, jpg, jpeg, jfif, heic, heif, webp, avif, jp2, tiff, tif, bmp
   </Card>
   <Card title="Audio" icon="music">
-    mp3, wav, aac, flac, webm, m4a, opus, ogg, aiff, amr
+    mp3, wav, aac, flac, webm, weba, m4a, opus, ogg, oga, aiff, amr
   </Card>
 </CardGroup>
 

--- a/integration/overview.mdx
+++ b/integration/overview.mdx
@@ -119,7 +119,7 @@ The `create()` function gives you complete control over the workflow:
 # Step 1: Create job
 result = client.v1.ai_image_generator.create(
     image_count=1,
-    orientation="landscape",
+    aspect_ratio="16:9",
     style={"prompt": "A sunset over mountains", "tool": "ai-anime-generator"},
     name="My image"
 )
@@ -152,7 +152,7 @@ The `generate()` function handles everything automatically:
 # All three steps handled automatically
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="landscape",
+    aspect_ratio="16:9",
     style={"prompt": "A sunset over mountains", "tool": "ai-anime-generator"},
     name="My image"
 )
@@ -189,7 +189,7 @@ Good for:
 # Using generate() - blocks until complete
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="landscape",
+    aspect_ratio="16:9",
     style={"prompt": "Test image", "tool": "ai-anime-generator"}
 )
 print(f"Image ready: {result.downloads[0].url}")
@@ -210,7 +210,7 @@ Good for:
 # Using create() with polling
 job = client.v1.ai_image_generator.create(
     image_count=1,
-    orientation="landscape",
+    aspect_ratio="16:9",
     style={"prompt": "Test image", "tool": "ai-anime-generator"}
 )
 
@@ -237,7 +237,7 @@ Good for:
 # Create job
 job = client.v1.ai_image_generator.create(
     image_count=1,
-    orientation="landscape",
+    aspect_ratio="16:9",
     style={"prompt": "Test image", "tool": "ai-anime-generator"}
 )
 
@@ -261,7 +261,7 @@ Begin with the `generate()` function to prototype:
 ```python
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="square",
+    aspect_ratio="1:1",
     style={"prompt": "Test image", "tool": "ai-anime-generator"}
 )
 ```

--- a/integration/webhook/create-handler.mdx
+++ b/integration/webhook/create-handler.mdx
@@ -211,14 +211,17 @@ app.listen(port, () => {
 Handle duplicate events gracefully (Magic Hour may retry):
 
 ```python
-# Check if event was already processed
-if await is_event_processed(event_id):
-    logger.info(f"Event {event_id} already processed, skipping")
+# Webhook payloads don't include an event ID, so build a dedup key
+# from the project ID and event type
+dedup_key = f"{event['payload']['id']}:{event['type']}"
+
+if await is_event_processed(dedup_key):
+    logger.info(f"Event {dedup_key} already processed, skipping")
     return {"success": True}
 
 # Process event and mark as processed
 await process_event(event)
-await mark_event_processed(event_id)
+await mark_event_processed(dedup_key)
 ```
 
 ### 2. Quick Response Times

--- a/integration/webhook/create-webhook.mdx
+++ b/integration/webhook/create-webhook.mdx
@@ -282,8 +282,10 @@ Enter your webhook details:
   - `video.started` - When video processing begins
   - `video.completed` - When video is ready for download
   - `video.errored` - When video processing fails
+  - `image.started` - When image processing begins
   - `image.completed` - When image is ready for download
   - `image.errored` - When image processing fails
+  - `audio.started` - When audio processing begins
   - `audio.completed` - When audio is ready for download
   - `audio.errored` - When audio processing fails
 
@@ -335,7 +337,7 @@ client = Client(token="your-api-key")
 # Create a simple AI image - this will trigger webhooks
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="square",
+    aspect_ratio="1:1",
     style={"prompt": "A cute cat wearing sunglasses", "tool": "ai-anime-generator"}
 )
 
@@ -351,7 +353,7 @@ curl -X POST "https://api.magichour.ai/v1/ai-image-generator" \
   -H "Content-Type: application/json" \
   -d '{
     "image_count": 1,
-    "orientation": "square",
+    "aspect_ratio": "1:1",
     "style": {
       "prompt": "A cute cat wearing sunglasses",
       "tool": "ai-anime-generator"
@@ -369,7 +371,7 @@ client = Client(token="your-api-key")
 
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="square",
+    aspect_ratio="1:1",
     style={"prompt": "A cute cat wearing sunglasses", "tool": "ai-anime-generator"}
 )
 

--- a/integration/webhook/event-types.mdx
+++ b/integration/webhook/event-types.mdx
@@ -63,7 +63,6 @@ Video events are triggered during the lifecycle of video processing jobs. All pa
     "created_at": "2024-10-19T05:10:19.027Z",
     "width": 512,
     "height": 960,
-    "total_frame_cost": 450,
     "credits_charged": 450,
     "downloads": [],
     "error": null
@@ -91,19 +90,19 @@ Video events are triggered during the lifecycle of video processing jobs. All pa
 
 ```json
 {
-  "type": "video.completed",
+    "type": "video.completed",
   "payload": {
     "id": "clx7uu86w0a5qp55yxz315r6r",
     "status": "complete",
     "type": "ANIMATION",
+    "credits_charged": 450,
     "downloads": [
       {
         "url": "https://videos.magichour.ai/clx7uu86w0a5qp55yxz315r6r/output.mp4",
         "expires_at": "2024-10-19T05:16:19.027Z"
       }
     ],
-    "error": null,
-    "completed_at": "2024-10-19T05:15:45.123Z"
+    "error": null
   }
 }
 ```
@@ -136,8 +135,7 @@ Video events are triggered during the lifecycle of video processing jobs. All pa
     "error": {
       "code": "invalid_video_file",
       "message": "The video file contains invalid data. Please try a different file."
-    },
-    "failed_at": "2024-10-19T05:12:30.456Z"
+    }
   }
 }
 ```
@@ -211,14 +209,15 @@ Image events track the lifecycle of image processing jobs. All payloads match th
     "id": "clx8abc123def456ghi789",
     "status": "complete",
     "type": "AI_IMAGE_GENERATOR",
+    "image_count": 1,
+    "credits_charged": 5,
     "downloads": [
       {
         "url": "https://videos.magichour.ai/clx8abc123def456ghi789/output.png",
         "expires_at": "2024-10-19T05:16:19.027Z"
       }
     ],
-    "error": null,
-    "completed_at": "2024-10-19T05:10:25.789Z"
+    "error": null
   }
 }
 ```
@@ -251,8 +250,7 @@ Image events track the lifecycle of image processing jobs. All payloads match th
     "error": {
       "code": "no_source_face",
       "message": "Please use an image with a detectable face"
-    },
-    "failed_at": "2024-10-19T05:10:22.123Z"
+    }
   }
 }
 ```
@@ -305,14 +303,14 @@ Audio events track the lifecycle of audio processing jobs. All payloads match th
   "payload": {
     "id": "clx9audio123voice456",
     "status": "complete",
+    "credits_charged": 5,
     "downloads": [
       {
         "url": "https://audio.magichour.ai/clx9audio123voice456/output.mp3",
         "expires_at": "2024-10-19T05:16:19.027Z"
       }
     ],
-    "error": null,
-    "completed_at": "2024-10-19T05:10:35.456Z"
+    "error": null
   }
 }
 ```
@@ -374,9 +372,10 @@ async def handle_completion_event(event):
     job_id = payload['id']
 
     # Update job status in database
+    # (the payload has no completed_at field - record your own timestamp)
     await db.execute(
-        "UPDATE jobs SET status = ?, download_url = ?, completed_at = ? WHERE magic_hour_id = ?",
-        (payload['status'], payload['downloads'][0]['url'], payload['completed_at'], job_id)
+        "UPDATE jobs SET status = ?, download_url = ?, completed_at = datetime('now') WHERE magic_hour_id = ?",
+        (payload['status'], payload['downloads'][0]['url'], job_id)
     )
 
     # Notify user

--- a/integration/webhook/overview.mdx
+++ b/integration/webhook/overview.mdx
@@ -341,7 +341,7 @@ client = Client(token="your-api-key")
 # Create a simple AI image - this will trigger webhooks
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="square",
+    aspect_ratio="1:1",
     style={"prompt": "A cute cat wearing sunglasses", "tool": "ai-anime-generator"}
 )
 
@@ -357,7 +357,7 @@ curl -X POST "https://api.magichour.ai/v1/ai-image-generator" \
   -H "Content-Type: application/json" \
   -d '{
     "image_count": 1,
-    "orientation": "square",
+    "aspect_ratio": "1:1",
     "style": {
       "prompt": "A cute cat wearing sunglasses",
       "tool": "ai-anime-generator"
@@ -375,7 +375,7 @@ client = Client(token="your-api-key")
 
 result = client.v1.ai_image_generator.generate(
     image_count=1,
-    orientation="square",
+    aspect_ratio="1:1",
     style={"prompt": "A cute cat wearing sunglasses", "tool": "ai-anime-generator"}
 )
 

--- a/integration/webhook/secure-handler.mdx
+++ b/integration/webhook/secure-handler.mdx
@@ -75,18 +75,6 @@ magic-hour-event-timestamp: 1729314984
 
 <Steps>
 
-<Step title="Extract Headers and Payload">
-
-Get the signature, timestamp, and raw JSON payload from the incoming request:
-
-```python
-signature = request.headers.get('magic-hour-event-signature')
-timestamp = request.headers.get('magic-hour-event-timestamp')
-raw_payload = await request.body()  # Raw JSON bytes, not parsed
-```
-
-</Step>
-
 <Step title="Extract the headers and payload">
 
 **What to do**: Get three pieces of information from the incoming webhook request:
@@ -426,11 +414,6 @@ app.post("/webhook", (req, res) => {
     return res.status(401).json({ error: "Missing security headers" });
   }
 
-  if (!signature || !timestamp) {
-    return res.status(401).json({ error: "Missing signature headers" });
-  }
-
-  const webhookSecret = process.env.MAGIC_HOUR_WEBHOOK_SECRET;
   if (!webhookSecret) {
     return res.status(500).json({ error: "Webhook secret not configured" });
   }
@@ -443,7 +426,12 @@ app.post("/webhook", (req, res) => {
   const computedSignature = computeSignature(signedPayload);
 
   // Constant-time comparison
-  if (signature !== computedSignature) {
+  const signatureBuffer = Buffer.from(signature);
+  const computedBuffer = Buffer.from(computedSignature);
+  if (
+    signatureBuffer.length !== computedBuffer.length ||
+    !crypto.timingSafeEqual(signatureBuffer, computedBuffer)
+  ) {
     return res.status(401).json({ error: "Invalid signature" });
   }
 

--- a/tools/audio/voice-cloner.mdx
+++ b/tools/audio/voice-cloner.mdx
@@ -86,7 +86,7 @@ For best results, your voice sample should:
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.ai_voice_cloner.generate(
     assets={
@@ -115,7 +115,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.aiVoiceCloner.generate({
   assets: {
@@ -239,7 +239,7 @@ Clone a voice, then sync it to a video:
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 # Step 1: Clone the voice
 from pathlib import Path
@@ -286,15 +286,13 @@ print("lip_status:", lip_sync_result.status, "paths:", getattr(lip_sync_result, 
 
 ## Pricing
 
-{/* TODO: Verify exact credit calculation */}
+Voice cloning costs **0.05 credits per character** of generated text, rounded up to the nearest whole number.
 
-Voice cloning uses credits based on text length and processing:
-
-| Text Length                | Approximate Credits |
-| :------------------------- | :------------------ |
-| Short (1-2 sentences)      | ~10 credits         |
-| Medium (paragraph)         | ~20-30 credits      |
-| Long (multiple paragraphs) | ~50+ credits        |
+| Text Length                       | Credits     |
+| :-------------------------------- | :---------- |
+| 100 characters (1-2 sentences)    | 5 credits   |
+| 500 characters (a paragraph)      | 25 credits  |
+| 2,000 characters (long-form)      | 100 credits |
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/audio/voice-generator.mdx
+++ b/tools/audio/voice-generator.mdx
@@ -93,7 +93,7 @@ Magic Hour offers a variety of celebrity and character voices:
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.ai_voice_generator.generate(
     style={
@@ -120,7 +120,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.aiVoiceGenerator.generate({
   style: {
@@ -234,7 +234,7 @@ Generate a voice, then sync it to a video:
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 # Step 1: Generate the voice
 from pathlib import Path
@@ -279,15 +279,13 @@ print("lip_status:", lip_sync_result.status, "paths:", getattr(lip_sync_result, 
 
 ## Pricing
 
-{/* TODO: Verify exact credit calculation */}
+Voice generation costs **0.05 credits per character** of text, rounded up to the nearest whole number.
 
-Voice generation uses credits based on text length:
-
-| Text Length                | Approximate Credits |
-| :------------------------- | :------------------ |
-| Short (1-2 sentences)      | ~5 credits          |
-| Medium (paragraph)         | ~10-20 credits      |
-| Long (multiple paragraphs) | ~30+ credits        |
+| Text Length                       | Credits     |
+| :-------------------------------- | :---------- |
+| 100 characters (1-2 sentences)    | 5 credits   |
+| 500 characters (a paragraph)      | 25 credits  |
+| 2,000 characters (long-form)      | 100 credits |
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/image/background-remover.mdx
+++ b/tools/image/background-remover.mdx
@@ -181,8 +181,6 @@ for (let i = 0; i < images.length; i++) {
 
 ## Pricing
 
-{/* TODO: Verify exact credit cost */}
-
 | Output               | Credits   |
 | :------------------- | :-------- |
 | 1 background removal | 5 credits |

--- a/tools/image/face-editor.mdx
+++ b/tools/image/face-editor.mdx
@@ -72,7 +72,7 @@ AI Face Editor provides advanced facial editing capabilities using AI to modify 
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.ai_face_editor.generate(
     assets={
@@ -114,7 +114,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.aiFaceEditor.generate({
   assets: {

--- a/tools/image/face-swap-photo.mdx
+++ b/tools/image/face-swap-photo.mdx
@@ -10,6 +10,8 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 Face Swap Photo lets you replace faces in static images with realistic precision and natural blending. The API swaps faces between two photos while preserving facial expressions, lighting conditions, and image quality for seamless results.
 
+**Typical processing time:** ~4s median ([see all processing times](/api-reference/processing-times))
+
 <ToolSection
   title="Face Swap Photo"
   productSlug="face-swap?mode=photo"
@@ -129,9 +131,9 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 Face Swap Photo uses a flat credit cost per image:
 
-| Output            | Credits   |
-| :---------------- | :-------- |
-| 1 face swap image | 5 credits |
+| Output            | Credits    |
+| :---------------- | :--------- |
+| 1 face swap image | 10 credits |
 
 <Info>
   Credits are charged when the job is created. If the job fails, credits are refunded automatically.

--- a/tools/image/gif-generator.mdx
+++ b/tools/image/gif-generator.mdx
@@ -50,7 +50,7 @@ AI GIF Generator creates animated GIFs using AI technology. Generate looping ani
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 result = client.v1.ai_gif_generator.generate(
     style={"prompt": "Cat fighting a lion, pixel art"},
     name="Ai Gif gif",
@@ -73,7 +73,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.aiGifGenerator.generate({
   assets: {
@@ -100,7 +100,7 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 | Output         | Credits    |
 | :------------- | :--------- |
-| 1 animated GIF | 15 credits |
+| 1 animated GIF | 50 credits |
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/image/headshot-generator.mdx
+++ b/tools/image/headshot-generator.mdx
@@ -127,8 +127,6 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-{/* TODO: Verify exact credit cost */}
-
 | Output     | Credits    |
 | :--------- | :--------- |
 | 1 headshot | 50 credits |

--- a/tools/image/image-editor.mdx
+++ b/tools/image/image-editor.mdx
@@ -10,6 +10,8 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 AI Image Editor provides comprehensive image editing capabilities using AI. Modify, enhance, and transform images with text-based instructions for natural-looking results without manual editing tools.
 
+**Typical processing time:** ~9s median ([see all processing times](/api-reference/processing-times))
+
 <ToolSection
   title="AI Image Editor"
   productSlug="ai-image-editor"
@@ -56,7 +58,7 @@ AI Image Editor provides comprehensive image editing capabilities using AI. Modi
 | Requirement | Details                             |
 | :---------- | :---------------------------------- |
 | Resolution  | Minimum 512x512 pixels              |
-| Format      | PNG, JPG, JPEG, WEBP                |
+| Format      | PNG, JPG, JPEG, JFIF, WEBP, HEIC, HEIF, AVIF, JP2, TIFF, TIF, BMP |
 | Quality     | Higher quality enables better edits |
 | Clarity     | Clear images edit more accurately   |
 
@@ -70,7 +72,7 @@ AI Image Editor provides comprehensive image editing capabilities using AI. Modi
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.ai_image_editor.generate(
     assets={
@@ -98,7 +100,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.aiImageEditor.generate({
   assets: {
@@ -124,9 +126,22 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-| Output         | Credits    |
-| :------------- | :--------- |
-| 1 edited image | 10 credits |
+Cost depends on the `model` you choose:
+
+| Model                | Credits per edit (from) |
+| :------------------- | :---------------------- |
+| `flux-2-klein`       | 5                       |
+| `qwen-edit`          | 10                      |
+| `seedream-v4`        | 40                      |
+| `gpt-image-2`        | 50                      |
+| `nano-banana`        | 50                      |
+| `nano-banana-2-lite` | 50                      |
+| `seedream-v4.5`      | 50                      |
+| `seedream-v5-pro`    | 75                      |
+| `nano-banana-2`      | 100                     |
+| `nano-banana-pro`    | 150                     |
+
+Higher resolutions can increase the cost — see the `model` parameter in the [API reference](/api-reference/image-projects/ai-image-editor) for supported resolutions and tiers per model.
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/image/image-generator.mdx
+++ b/tools/image/image-generator.mdx
@@ -8,7 +8,9 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 ## Overview
 
-AI Image Generator creates high-quality images from text descriptions using advanced AI models. The API generates original artwork, photos, illustrations, and designs based on detailed text prompts with customizable styles, orientations, and resolutions.
+AI Image Generator creates high-quality images from text descriptions using advanced AI models. The API generates original artwork, photos, illustrations, and designs based on detailed text prompts with customizable styles, aspect ratios, and resolutions.
+
+**Typical processing time:** ~5s median ([see all processing times](/api-reference/processing-times))
 
 <ToolSection
   title="AI Image Generator"
@@ -29,7 +31,7 @@ AI Image Generator creates high-quality images from text descriptions using adva
 
 1. **Write a prompt** - Describe the image you want to create
 2. **Choose a style** - Select from 30+ art styles and tools
-3. **Set orientation** - Choose square, landscape, or portrait
+3. **Set the aspect ratio** - Choose `1:1`, `16:9`, or `9:16`
 4. **API generates images** - AI creates images matching your description
 5. **Download results** - Retrieve your generated images
 
@@ -70,13 +72,15 @@ Magic Hour offers 30+ art styles. Match the style to your use case:
 | Logos & icons    | Vector, Minimalist         |
 | Concept art      | Digital Art, Fantasy       |
 
-### Orientation Guidelines
+### Aspect Ratio Guidelines
 
-| Orientation | Aspect Ratio | Best For                                   |
-| :---------- | :----------- | :----------------------------------------- |
-| `square`    | 1:1          | Profile pictures, thumbnails, social posts |
-| `landscape` | 16:9         | Banners, headers, desktop wallpapers       |
-| `portrait`  | 9:16         | Stories, mobile wallpapers, posters        |
+Set the `aspect_ratio` parameter to control the output shape:
+
+| `aspect_ratio` | Shape     | Best For                                   |
+| :------------- | :-------- | :----------------------------------------- |
+| `1:1`          | Square    | Profile pictures, thumbnails, social posts |
+| `16:9`         | Landscape | Banners, headers, desktop wallpapers       |
+| `9:16`         | Portrait  | Stories, mobile wallpapers, posters        |
 
 ## Code Examples
 
@@ -241,10 +245,22 @@ console.log(`Credits charged: ${result.creditsCharged}`);
 
 ## Pricing
 
-| Quality     | Credits per Image |
-| :---------- | :---------------- |
-| Standard    | 5 credits         |
-| Pro quality | 30 credits        |
+Cost depends on the `model` you choose (the default model is picked automatically and may change over time):
+
+| Model                | Credits per image (from) | Tiers                        |
+| :------------------- | :----------------------- | :--------------------------- |
+| `flux-schnell`       | 5                        | All (including free)         |
+| `flux-2-klein`       | 5                        | All (including free)         |
+| `z-image-turbo`      | 5                        | All (including free)         |
+| `seedream-v4`        | 40                       | Creator, Pro, Business       |
+| `gpt-image-2`        | 50                       | Creator, Pro, Business       |
+| `nano-banana`        | 50                       | Creator, Pro, Business       |
+| `nano-banana-2-lite` | 50                       | Creator, Pro, Business       |
+| `seedream-v5-pro`    | 75                       | Creator, Pro, Business       |
+| `nano-banana-2`      | 100                      | Creator, Pro, Business       |
+| `nano-banana-pro`    | 150                      | Creator, Pro, Business       |
+
+Higher resolutions can increase the cost — see the `model` parameter in the [API reference](/api-reference/image-projects/ai-image-generator) for supported resolutions and image counts per model.
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/image/image-upscaler.mdx
+++ b/tools/image/image-upscaler.mdx
@@ -85,7 +85,7 @@ AI Image Upscaler enhances image resolution and quality using AI-powered upscali
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.ai_image_upscaler.generate(
     assets={
@@ -114,7 +114,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.aiImageUpscaler.generate({
   assets: {

--- a/tools/image/photo-colorizer.mdx
+++ b/tools/image/photo-colorizer.mdx
@@ -71,7 +71,7 @@ Photo Colorizer brings black and white photos to life by adding realistic, histo
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.photo_colorizer.generate(
     assets={
@@ -96,7 +96,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.photoColorizer.generate({
   assets: {

--- a/tools/image/qr-code-generator.mdx
+++ b/tools/image/qr-code-generator.mdx
@@ -176,14 +176,11 @@ console.log(`✅ Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-<Tip>
-  **Currently Free** - QR Code Generator is temporarily free to use. Normally, each QR code costs 5
-  credits.
-</Tip>
+<Tip>**Free** - Each QR code costs 0 credits.</Tip>
 
-| Output    | Credits                               |
-| :-------- | :------------------------------------ |
-| 1 QR code | Temporarily free (normally 5 credits) |
+| Output    | Credits           |
+| :-------- | :---------------- |
+| 1 QR code | 0 credits (free) |
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/video/auto-subtitle-generator.mdx
+++ b/tools/video/auto-subtitle-generator.mdx
@@ -69,7 +69,7 @@ Auto Subtitle Generator uses Whisper AI which supports 90+ languages with automa
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.auto_subtitle_generator.generate(
     assets={
@@ -97,7 +97,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.autoSubtitleGenerator.generate({
   assets: {

--- a/tools/video/face-swap-video.mdx
+++ b/tools/video/face-swap-video.mdx
@@ -10,6 +10,8 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 Face Swap Video replaces faces in videos with frame-by-frame precision and temporal consistency. The API swaps faces throughout video sequences while maintaining natural expressions, head movements, and lighting for realistic results.
 
+**Typical processing time:** ~1m 36s median ([see all processing times](/api-reference/processing-times))
+
 <ToolSection
   title="Face Swap Video"
   productSlug="face-swap?mode=video"
@@ -137,9 +139,7 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-Face Swap Video uses credits based on video duration and frame rate:
-
-{/* TODO: Verify exact credit calculation */}
+Face Swap Video uses credits based on video duration and frame rate — credits are only charged for the frames that actually render:
 
 | Factor     | Impact                      |
 | :--------- | :-------------------------- |
@@ -147,7 +147,7 @@ Face Swap Video uses credits based on video duration and frame rate:
 | Frame rate | Higher FPS = more credits   |
 | Resolution | Affects quality, not cost   |
 
-**Example:** A 10-second video at 30 FPS ≈ 300 credits
+The create response returns an estimated `credits_charged` based on 30 FPS; the final amount is adjusted after the render completes if the actual frame rate differs. Check the completed job's `credits_charged` for the exact cost.
 
 ## Error Handling
 

--- a/tools/video/image-to-video.mdx
+++ b/tools/video/image-to-video.mdx
@@ -10,6 +10,8 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 Image to Video converts static images into dynamic video content with AI-generated motion and cinematic effects. The API analyzes images and creates realistic movement, camera motion, and environmental effects to bring still photos to life.
 
+**Typical processing time:** ~1m 14s median ([see all processing times](/api-reference/processing-times))
+
 <ToolSection
   title="Image to Video"
   productSlug="image-to-video"
@@ -129,7 +131,7 @@ const result = await client.v1.imageToVideo.generate({
   style: {
     prompt: "Sunset landscape with subtle camera movement, gentle parallax effect, cinematic depth",
   },
-  endSeconds: 1.5,
+  endSeconds: 5,
   name: "Sunset Animation",
   resolution: "480p",
   waitForCompletion: true,
@@ -146,20 +148,11 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-Image to Video uses credits based on video duration:
-
-{/* TODO: Verify exact credit calculation */}
-
-| Duration   | Approximate Credits |
-| :--------- | :------------------ |
-| 5 seconds  | ~150 credits        |
-| 10 seconds | ~300 credits        |
-
-Higher resolutions cost more per second.
+Image to Video pricing depends on the model, resolution, and duration you choose. Credits are only charged for the frames that actually render — the estimate returned when you create the job is adjusted after the render completes. The create response includes `credits_charged` so you can log the exact cost of every job.
 
 ## Resolution Limits
 
-Image to Video has a maximum resolution of **1080p** (1920x1080 or 1080x1920).
+Supported resolutions are **480p, 720p, 1080p, and 4k**, depending on the model (for example, `kling-3.0` supports 4k) and your subscription tier. Output defaults to `720p` on paid tiers and `480p` on the free tier. See [Resolution Limits](/billing/resolution-limits) for tier details.
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/video/lip-sync.mdx
+++ b/tools/video/lip-sync.mdx
@@ -10,6 +10,8 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 Lip Sync synchronizes lip movements in videos with new audio tracks using advanced AI motion analysis. The API creates realistic lip-sync animation that matches speech patterns, timing, and mouth movements for natural-looking results.
 
+**Typical processing time:** ~3m 49s median ([see all processing times](/api-reference/processing-times))
+
 <ToolSection
   title="Lip Sync"
   productSlug="lip-sync"
@@ -58,7 +60,7 @@ Lip Sync synchronizes lip movements in videos with new audio tracks using advanc
 
 - **Clear speech** - Well-recorded audio without background noise
 - **Appropriate length** - Audio duration determines output length
-- **Supported formats** - MP3, WAV, AAC, FLAC
+- **Supported formats** - MP3, WAV, AAC, FLAC, M4A, OPUS, OGG/OGA, WEBM/WEBA, AIFF, AMR
 - **Natural pacing** - Normal speaking pace for best results
 
 ### Matching Audio to Video
@@ -144,14 +146,15 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-Lip Sync uses credits based on video duration:
+Lip Sync is charged per rendered frame, and the rate depends on `style.generation_mode`:
 
-{/* TODO: Verify exact credit calculation */}
+| Generation mode      | Credits per frame | Notes                                          |
+| :------------------- | :---------------- | :--------------------------------------------- |
+| `lite`               | 1                 | Available on all tiers                         |
+| `standard`           | 1                 | Creator, Pro, and Business tiers only          |
+| `pro`                | 2                 | Creator, Pro, and Business tiers only          |
 
-| Duration   | Approximate Credits |
-| :--------- | :------------------ |
-| 5 seconds  | ~150 credits        |
-| 10 seconds | ~300 credits        |
+For example, a 10-second clip capped at 30 FPS in `lite` mode costs about 300 credits. Use `max_fps_limit` to lower the frame rate and reduce cost. Credits are only charged for the frames that actually render, and the completed job's `credits_charged` shows the exact cost.
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/video/talking-photo.mdx
+++ b/tools/video/talking-photo.mdx
@@ -8,7 +8,9 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 ## Overview
 
-AI Talking Photo brings static photos to life by animating faces to speak with realistic lip-sync and natural facial movements. The API analyzes facial features and synchronizes mouth movements, head poses, and expressions with provided audio or generated speech.
+AI Talking Photo brings static photos to life by animating faces to speak with realistic lip-sync and natural facial movements. The API analyzes facial features and synchronizes mouth movements, head poses, and expressions with the audio file you provide.
+
+**Typical processing time:** ~2m 54s median ([see all processing times](/api-reference/processing-times))
 
 <ToolSection
   title="AI Talking Photo"
@@ -28,7 +30,7 @@ AI Talking Photo brings static photos to life by animating faces to speak with r
 ## How It Works
 
 1. **Provide a photo** - Upload an image with a clear face
-2. **Add audio** - Upload audio or provide text for speech generation
+2. **Add audio** - Provide an audio file (required). To generate speech from text, create the audio first with the [AI Voice Generator](/tools/audio/voice-generator)
 3. **API animates** - AI creates realistic lip-sync and facial movements
 4. **Download video** - Retrieve your animated talking photo
 
@@ -56,16 +58,16 @@ AI Talking Photo brings static photos to life by animating faces to speak with r
 
 ### Audio Guidelines
 
-| Audio Type       | Best Practice                          |
-| :--------------- | :------------------------------------- |
-| Voice recording  | Clear speech without background noise  |
-| Generated speech | Use natural-sounding text prompts      |
-| Music/songs      | Works best with clear vocals           |
-| Length           | Keep under 30 seconds for best results |
+| Audio Type       | Best Practice                                                                     |
+| :--------------- | :-------------------------------------------------------------------------------- |
+| Voice recording  | Clear speech without background noise                                              |
+| Generated speech | Create the audio first with the [AI Voice Generator](/tools/audio/voice-generator) |
+| Music/songs      | Works best with clear vocals                                                       |
+| Length           | Keep under 30 seconds for best results                                             |
 
 ## Code Examples
 
-### Basic Talking Photo with Text
+### Basic Talking Photo
 
 <CodeGroup>
 
@@ -73,7 +75,7 @@ AI Talking Photo brings static photos to life by animating faces to speak with r
 from magic_hour import Client
 from os import getenv
 
-client = Client(token=getenv("API_TOKEN"))
+client = Client(token=getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.ai_talking_photo.generate(
     assets={
@@ -101,7 +103,7 @@ else:
 ```javascript Node.js
 import { Client } from "magic-hour";
 
-const client = new Client({ token: process.env.API_TOKEN });
+const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.aiTalkingPhoto.generate({
   assets: {
@@ -124,64 +126,18 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 </CodeGroup>
 
-### With Audio File
-
-<CodeGroup>
-
-```python Python
-result = client.v1.ai_talking_photo.generate(
-    assets={
-        "image_file_path": "https://raw.githubusercontent.com/runshouse/Sample_Assets/main/tomcruise.png",
-        "audio_file_path": "https://raw.githubusercontent.com/runshouse/Sample_Assets/main/you-are-just-a-line-of-code.mp3"
-    },
-    name="Talking Photo",
-    wait_for_completion=True,
-    download_outputs=True,
-    download_directory="."
-)
-
-if result.status == "complete":
-    print(f"✅ Talking photo complete!")
-    print(f"Downloaded to: {result.downloaded_paths}")
-    print(f"Credits charged: {result.credits_charged}")
-else:
-    print(f"❌ Job failed with status: {result.status}")
-    if hasattr(result, 'error_message'):
-        print(f"Error: {result.error_message}")
-```
-
-```javascript Node.js
-const result = await client.v1.aiTalkingPhoto.generate({
-  assets: {
-    imageFilePath: "https://raw.githubusercontent.com/runshouse/Sample_Assets/main/tomcruise.png",
-    audioFilePath:
-      "https://raw.githubusercontent.com/runshouse/Sample_Assets/main/you-are-just-a-line-of-code.mp3",
-  },
-  name: "Talking Photo",
-  waitForCompletion: true,
-  downloadOutputs: true,
-  downloadDirectory: ".",
-});
-
-console.log(`✅ Talking photo complete!`);
-console.log(`Status: ${result.status}`);
-console.log(`Downloaded to: ${result.downloadedPaths}`);
-```
-
-</CodeGroup>
+<Note>
+  `start_seconds` and `end_seconds` are **required** — they control which segment of the audio is
+  used. Video pricing is duration-based, so shorter segments cost less.
+</Note>
 
 ## Pricing
 
-Talking Photo pricing varies by video length and resolution:
-
-| Configuration     | Credits per Second |
-| :---------------- | :----------------- |
-| 720p or lower     | ~10-15 credits/sec |
-| Higher resolution | ~20-30 credits/sec |
+Talking Photo pricing is based on the duration of the output video (`end_seconds` minus `start_seconds`). Credits are only charged for the frames that actually render, and the create response includes `credits_charged` so you can log the exact cost of every job.
 
 ## Resolution Limits
 
-AI Talking Photo has a maximum resolution of **720p** across all subscription tiers due to computational requirements.
+Output resolution is capped at **720p** (the tool's hard cap) or your subscription plan's maximum resolution, whichever is lower. You can also set `max_resolution` below your plan maximum to reduce cost. See [Resolution Limits](/billing/resolution-limits) for tier details.
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/video/text-to-video.mdx
+++ b/tools/video/text-to-video.mdx
@@ -10,19 +10,13 @@ import { ToolSection } from "/snippets/tool-section.mdx";
 
 Text to Video generates complete video content from text descriptions using advanced AI video synthesis. The API creates original video scenes, animations, and visual narratives based on detailed text prompts with customizable styles and durations.
 
+**Typical processing time:** ~51s median ([see all processing times](/api-reference/processing-times))
+
 <ToolSection
   title="Text to Video"
   productSlug="text-to-video"
   apiSlug="text-to-video"
   type="video"
-  outputs={[
-    {
-      src: "https://d28dkohlqf5vwj.cloudfront.net/products/text-to-video/examples/underwater-world.mp4",
-    },
-    {
-      src: "https://d28dkohlqf5vwj.cloudfront.net/products/text-to-video/examples/slow-motion-leopard-leap.mp4",
-    },
-  ]}
 />
 
 ## How It Works
@@ -79,6 +73,7 @@ For best results, include these elements:
 | 3-5 seconds   | Social media clips, GIF-like content |
 | 5-10 seconds  | Short-form content, product demos    |
 | 10-15 seconds | Story segments, longer narratives    |
+| Up to 60 seconds | Long-form scenes (model-dependent; see the `end_seconds` values supported by each model in the [API reference](/api-reference/video-projects/text-to-video)) |
 
 ## Code Examples
 
@@ -94,7 +89,7 @@ client = Client(token=os.getenv("MAGIC_HOUR_API_KEY"))
 
 result = client.v1.text_to_video.generate(
     end_seconds=5,
-    orientation="landscape",
+    aspect_ratio="16:9",
     style={
         "prompt": "A majestic lion walking through golden savanna grass at sunset, cinematic slow motion"
     },
@@ -121,8 +116,8 @@ import { Client } from "magic-hour";
 const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 
 const result = await client.v1.textToVideo.generate({
-  endSeconds: 1.5,
-  orientation: "landscape",
+  endSeconds: 5,
+  aspectRatio: "16:9",
   style: {
     prompt: "A majestic lion walking through golden savanna grass at sunset, cinematic slow motion",
   },
@@ -142,20 +137,11 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-Text to Video uses credits based on video duration:
-
-{/* TODO: Verify exact credit calculation */}
-
-| Duration   | Approximate Credits |
-| :--------- | :------------------ |
-| 5 seconds  | ~150 credits        |
-| 10 seconds | ~300 credits        |
-
-Higher resolutions cost more per second.
+Text to Video pricing depends on the model, resolution, and duration you choose. Credits are only charged for the frames that actually render — the estimate returned when you create the job is adjusted after the render completes. The create response includes `credits_charged` so you can log the exact cost of every job.
 
 ## Resolution Limits
 
-Text to Video has a maximum resolution of **1080p** (1920x1080 or 1080x1920).
+Supported resolutions are **480p, 720p, 1080p, and 4k**, depending on the model (for example, `kling-3.0` supports 4k) and your subscription tier. Output defaults to `720p` on paid tiers and `480p` on the free tier. See [Resolution Limits](/billing/resolution-limits) for tier details.
 
 <Tip>
   **Try this in our Google Colab Cookbook:** [Run this API with sample

--- a/tools/video/video-to-video.mdx
+++ b/tools/video/video-to-video.mdx
@@ -163,9 +163,7 @@ console.log(`Downloaded to: ${result.downloadedPaths}`);
 
 ## Pricing
 
-Video to Video uses credits based on video duration and frame rate:
-
-{/* TODO: Verify exact credit calculation */}
+Video to Video uses credits based on video duration and frame rate. Credits are only charged for the frames that actually render — you'll see an estimate when the job is queued and the final total after it's done (in the job's `credits_charged` field).
 
 | Factor     | Impact                           |
 | :--------- | :------------------------------- |


### PR DESCRIPTION
## Summary

High-confidence fixes from a full docs audit, every change verified against the OpenAPI spec (`api-reference/openapi.json`, `webhook-reference/openapi.json`) and the published SDKs (Python 0.72.0, Node 0.70.0, Go 0.71.0, Rust 0.64.0). 35 files changed.

### Pricing correctness (top support pain point)
- Face Swap Photo 5 → **10** credits; GIF Generator 15 → **50**; QR Code → **0 (free)**, spec-sourced
- Replaced fabricated Talking Photo per-second rate table and stale Image Generator "Standard 5 / Pro 30" table with per-model costs from the spec
- Resolved all `TODO: Verify exact credit calculation` placeholders: voice generator/cloner **0.05 credits/character**, headshot **50**, background remover **5**, lip sync **1–2 credits/frame by generation mode**, frame-based costs for the video tools
- Fixed billing contradiction: subscription credits **never expire** (was "can expire unused"); free tier 512px → **576px**

### Examples that didn't run
- `orientation` → `aspect_ratio` in ~20 code samples (param no longer exists in the spec; requests fail with 400)
- `endSeconds: 1.5` → `5` (below every model's minimum duration)
- Stale Go/Rust type names (`PostV1FaceSwapBodyAssets`, `GetV1ImageProjectsIdResponseStatusEnum`, …) → current `V1*Create/Get` names in quickstart and file-upload guides
- `Environment.PRODUCTION` → `Environment.ENVIRONMENT` (Python) and `Environment.Production` → `Environment.Environment` (Node) — the documented members don't exist and crash on import
- Quickstart `echo '{"type":"module"}' > package.json` (clobbered the file right after `npm init`) → `npm pkg set type=module`
- Polling examples: reachable timeouts, real exponential backoff, and terminal `error`/`canceled` states no longer swallowed by a bare `except`
- Dropped deprecated `height`/`width` from face-swap examples; pinned tutorial dependency `^0.42.0` → `^0.70.0`

### Env var standardization
- `API_TOKEN` / `API_KEY` → `MAGIC_HOUR_API_KEY` across 10 tool/integration pages (copy-pasted snippets previously failed auth after following the quickstart)

### Webhooks
- Added missing `image.started` / `audio.started` to the event list
- Removed payload fields that don't exist in the webhook spec (`total_frame_cost`, `completed_at`, `failed_at`) and added real ones (`credits_charged`, `image_count`)
- Node handler: `crypto.timingSafeEqual` for signature comparison (docs claimed constant-time but used `!==`), removed duplicated header-check/secret blocks and a duplicated tutorial step
- Idempotency example now builds a dedup key from `payload.id` + `type` (payloads have no `event_id`)
- Added orphaned `create-handler` page to navigation

### Stale claims and navigation
- Text-to-Video / Image-to-Video "max 1080p" → up to **4k** (model-dependent, per spec enum), aligned with `billing/resolution-limits`
- Removed two Text-to-Video demo videos returning CloudFront 403
- Talking Photo: removed text-to-speech claims (audio file is required per schema); removed a redundant example missing required `start_seconds`/`end_seconds`
- Redirect `ai-photo-editor` → `ai-image-editor` (was a hard 404 with search/inbound links)
- Fixed wrong screenshot in the API-key management section; de-numbered stale "all 22 APIs" claims (spec has 27 generation endpoints)
- Added median processing times (from `/api-reference/processing-times`) to the 8 priority tool pages; quickstart error table now covers 403/429; quickstart "API Reference" next-step now points to the overview instead of file-upload; added `ref=docs-quickstart` to the key-creation link for funnel attribution

## Not included (needs upstream/product input)
- OpenAPI spec fixes (46 boilerplate endpoint descriptions, talking-photo "audio or text" summary) — spec is regenerated daily; must be fixed in the source pipeline
- SDK bugs (Python `generate()` stale resolution literal + deprecated required `orientation` in async variant, Node untyped `node-fetch` transitive dep) — separate SDK repos
- Colab notebook missing 6 newer APIs — external notebook
- Rate-limit/concurrency numbers and a video pricing calculator — need product data

## Test plan
- [x] `yarn check` (mintlify broken-links): no broken links
- [x] `docs.json` valid JSON; nav renders new webhook page
- [x] All credit numbers, enums, and type names diffed against `openapi.json` and cloned SDK sources
- [ ] Preview deploy: spot-check text-to-video, talking-photo, webhook pages

Made with [Cursor](https://cursor.com)