### PR TITLE
fix: correct API paths, broken code samples, and stale pricing

### DIFF
--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -17,9 +17,9 @@ a project ID immediately; use the matching details endpoint or a webhook to trac
 
 ## Files
 
-- [`POST /v1/files/generate-upload-urls`](/api-reference/files/generate-asset-upload-urls) — Generate asset upload URLs
-- [`GET /v1/files/:id/face-detection`](/api-reference/files/get-face-detection-details) — Get face detection details
-- [`POST /v1/files/face-detection`](/api-reference/files/face-detection) — Detect faces in an asset
+- [`POST /v1/files/upload-urls`](/api-reference/files/generate-asset-upload-urls) — Generate asset upload URLs
+- [`POST /v1/face-detection`](/api-reference/files/face-detection) — Detect faces in an asset
+- [`GET /v1/face-detection/:id`](/api-reference/files/get-face-detection-details) — Get face detection details
 
 ## Video projects
 

--- a/billing/overview.mdx
+++ b/billing/overview.mdx
@@ -47,14 +47,17 @@ Pay upfront for credits that never expire. Perfect for steady, predictable usage
 
 - **Predictable costs** - Know exactly what you'll pay
 - **Credits upfront** - Get all credits immediately
-- **Yearly savings** - Get 33% off with annual billing
+- **Yearly savings** - Annual billing is discounted
 - **No usage tracking** - Use credits at your own pace
 
 **Plans Available:**
 
-- **Creator**: \$15/mo or \$10/mo (yearly) - 10,000 credits, 1024px resolution
-- **Pro**: \$45/mo or \$30/mo (yearly) - 30,000 credits, 1472px resolution
-- **Business**: \$99/mo or \$66/mo (yearly) - 70,000 credits, 4K resolution
+- **Creator**: 1024px resolution
+- **Pro**: 1472px resolution
+- **Business**: 4K resolution
+
+Current prices, credit allowances, and credit packs are on the
+[pricing page](https://magichour.ai/pricing).
 
 <Card
   title="Subscription Details"
@@ -76,12 +79,15 @@ Pay only for what you use, with automatic volume discounts as you scale.
 - **Automatic billing** - Monthly charges based on usage
 - **Perfect for growth** - Scales with your business
 
-**Tier Examples:**
+**Tiers:**
 
-- **Starter**: \$0.90 per 1000 credits (576px resolution)
-- **Creator**: \$1.20 per 1000 credits (1024px resolution)
-- **Pro**: \$1.95 per 1000 credits (1472px resolution)
-- **Business**: \$2.50 per 1000 credits (4K resolution)
+- **Starter**: 576px resolution
+- **Creator**: 1024px resolution
+- **Pro**: 1472px resolution
+- **Business**: 4K resolution
+
+Rates rise with the resolution tier and fall automatically with volume. Estimate your bill with the
+[API cost calculator](https://magichour.ai/api#api-cost-calculator).
 
 <Card title="Usage-Based Details" icon="chart-line" href="/billing/usage-based-pricing" horizontal>
   View usage-based pricing and discounts

--- a/billing/subscription-pricing.mdx
+++ b/billing/subscription-pricing.mdx
@@ -10,7 +10,7 @@ description: Get credits upfront with predictable monthly or yearly billing and 
 ### **The Basics**
 
 1. **Choose your plan** based on resolution needs and monthly credit requirements
-2. **Select billing frequency** - monthly or yearly (yearly saves 33%)
+2. **Select billing frequency** - monthly or yearly (annual billing is discounted)
 3. **Pay upfront** and receive all credits immediately
 4. **Use credits anytime** - credits never expire, even after subscription ends
 5. **Auto-renewal** ensures continuous access (can be cancelled anytime)
@@ -19,7 +19,7 @@ description: Get credits upfront with predictable monthly or yearly billing and 
 
 ✅ **Predictable costs** - Know exactly what you'll pay each month/year  
 ✅ **Credits upfront** - Get all your credits immediately to use anytime  
-✅ **Yearly savings** - Get 33% off with annual billing  
+✅ **Yearly savings** - Annual billing is discounted  
 ✅ **No usage tracking** - Use credits at your own pace  
 ✅ **Higher resolution** - Access to better quality based on your tier
 
@@ -36,6 +36,11 @@ description: Get credits upfront with predictable monthly or yearly billing and 
 ## Choose Your Plan
 
 Each plan offers different credit amounts and resolution limits. Higher plans unlock better resolution and more credits per month.
+
+<Info>
+  Prices and credit allowances live on the [pricing page](https://magichour.ai/pricing) so they're
+  always current. This page covers how the plans behave.
+</Info>
 
 import { PricingCard } from "/snippets/pricing-card.mdx";
 
@@ -54,46 +59,20 @@ import { PricingCard } from "/snippets/pricing-card.mdx";
 
 <PricingCard
   title="Creator"
-  prices={[
-    { amount: 15, label: "/ month" },
-    { amount: 120, label: "/ year" },
-  ]}
-  benefits={[
-    "10,000 credits per month (120,000/year)",
-    "1024px resolution",
-    "No watermarks",
-    "Commercial use license",
-  ]}
+  benefits={["1024px resolution", "No watermarks", "Commercial use license"]}
 />
 
-<PricingCard
-  title="Pro"
-  prices={[
-    { amount: 45, label: "/ month" },
-    { amount: 360, label: "/ year" },
-  ]}
-  benefits={[
-    "30,000 credits per month (360,000/year)",
-    "1472px resolution",
-    "5GB file uploads",
-    "Priority support",
-  ]}
-/>
+<PricingCard title="Pro" benefits={["1472px resolution", "5GB file uploads", "Priority support"]} />
 
 <PricingCard
   title="Business"
-  prices={[
-    { amount: 99, label: "/ month" },
-    { amount: 792, label: "/ year" },
-  ]}
-  benefits={[
-    "70,000 credits per month (840,000/year)",
-    "4K resolution for select modes",
-    "10GB file uploads",
-    "Priority support",
-  ]}
+  benefits={["4K resolution for select modes", "10GB file uploads", "Priority support"]}
 />
 </CardGroup>
+
+<Card title="See plans and prices" icon="tag" href="https://magichour.ai/pricing" horizontal>
+  Current monthly and annual pricing, credit allowances, and credit packs
+</Card>
 
 ## Need More Credits?
 
@@ -101,8 +80,7 @@ If you use more credits than your plan includes, you can purchase additional cre
 
 ### **Credit Packs**
 
-- **1,000 credits per pack**
-- **\$3.00 per pack** (\$0.003 per credit)
+- **Fixed pack sizes** - see the [pricing page](https://magichour.ai/pricing) for current sizes and prices
 - **Instant delivery** - credits added immediately to your account
 - **No expiration** - credits never expire, even after subscription ends
 
@@ -118,35 +96,15 @@ If you use more credits than your plan includes, you can purchase additional cre
   better value.
 </Note>
 
-## Practical Examples
+## Choosing a Plan
 
-### **Content Creator (5,000 credits/month)**
+Pick the plan whose resolution ceiling matches your output requirements, then check that its credit
+allowance covers your expected monthly volume. If you regularly exhaust your allowance and buy credit
+packs, the next tier up is usually cheaper than the packs.
 
-- **Free Plan**: 400 + (100 × 30 days) = 3,400 credits/month - **Not enough**
-- **Creator Plan**: 10,000 credits/month from \$10/mo (billed annually) - **Perfect fit**
-
-_Creator plan gives you 2x your needs with room to grow_
-
-### **Marketing Agency (35,000 credits/month)**
-
-- **Creator Plan**: 10,000 credits + 25 credit packs = \$10 + \$75 = **\$85/month**
-- **Pro Plan**: 30,000 credits + 5 credit packs = \$30 + \$15 = **\$45/month** - **Better value**
-
-_Pro plan saves \$40/month and provides buffer for growth_
-
-### **Enterprise (200,000 credits/month)**
-
-- **Pro Plan**: 30,000 + 170 credit packs = \$30 + \$510 = **\$540/month**
-- **Business Plan**: 70,000 credits + 130 credit packs = \$66 + \$390 = **\$456/month** - **Much better value**
-
-_Business plan saves \$84/month and includes 4K resolution_
-
-### **Yearly vs Monthly Savings**
-
-**Pro Plan Example:**
-
-- **Monthly**: \$45 × 12 = **\$540/year**
-- **Yearly**: **\$360/year** (33% off - equivalent to \$30/month)
+For API workloads with variable volume, compare against
+[usage-based pricing](/billing/usage-based-pricing), which bills after the fact and applies volume
+discounts automatically.
 
 ## Getting Started
 
@@ -160,15 +118,15 @@ Ready to subscribe? Here's how to set up your subscription in minutes.
 </Step>
 
 <Step title="Choose Billing Frequency">
-  **Monthly**: Pay monthly, cancel anytime **Yearly**: Pay upfront, get 33% off ![Pricing
+  **Monthly**: Pay monthly, cancel anytime **Yearly**: Pay upfront at a discount ![Pricing
   Page](./images/pricing-page-2.png)
 </Step>
 
 <Step title="Select Your Plan">
   Choose based on your monthly credit needs and resolution requirements:
-  - **Creator**: 10,000 credits/month, 1024px resolution
-  - **Pro**: 30,000 credits/month, 1472px resolution  
-  - **Business**: 70,000 credits/month, 4096px resolution
+  - **Creator**: 1024px resolution
+  - **Pro**: 1472px resolution
+  - **Business**: 4096px resolution
 
 ![Pricing Page](./images/pricing-page-3.png)
 

--- a/billing/usage-based-pricing.mdx
+++ b/billing/usage-based-pricing.mdx
@@ -25,13 +25,13 @@ description: Pay only for what you use with automatic monthly billing and volume
 
 ### **How It Differs from Subscriptions**
 
-| Usage-Based                | Subscription               |
-| :------------------------- | :------------------------- |
-| Pay after you use          | Pay upfront                |
-| Automatic monthly billing  | Manual credit purchases    |
-| Volume discounts included  | Fixed credit amounts       |
+| Usage-Based                | Subscription                 |
+| :------------------------- | :--------------------------- |
+| Pay after you use          | Pay upfront                  |
+| Automatic monthly billing  | Manual credit purchases      |
+| Volume discounts included  | Fixed credit amounts         |
 | No unused credits          | Prepaid credits never expire |
-| Perfect for variable usage | Good for predictable usage |
+| Perfect for variable usage | Good for predictable usage   |
 
 ## Choose Your Tier
 
@@ -43,7 +43,6 @@ import { PricingCard } from "/snippets/pricing-card.mdx";
 
 <PricingCard
   title="Starter"
-  prices={[{ amount: "0.90", label: "/ 1000 credits" }]}
   benefits={[
     "576x576 resolution",
     "Access to all image modes",
@@ -53,19 +52,16 @@ import { PricingCard } from "/snippets/pricing-card.mdx";
 
 <PricingCard
   title="Creator"
-  prices={[{ amount: "1.20", label: "/ 1000 credits" }]}
   benefits={["1024x1024 resolution", "Access to all image modes", "Access to all video modes"]}
 />
 
 <PricingCard
   title="Pro"
-  prices={[{ amount: "1.95", label: "/ 1000 credits" }]}
   benefits={["1472x1472 resolution", "Access to all image modes", "Access to all video modes"]}
 />
 
 <PricingCard
   title="Business"
-   prices={[{ amount: "2.50", label: "/ 1000 credits" }]}
   benefits={[
     "4096x4096 resolution for select modes",
     "Access to all image modes",
@@ -74,95 +70,41 @@ import { PricingCard } from "/snippets/pricing-card.mdx";
 />
 </CardGroup>
 
+Each tier has its own rate per 1,000 credits, rising with the resolution ceiling. Get current rates
+and model your monthly bill with the
+[API cost calculator](https://magichour.ai/api#api-cost-calculator).
+
 ## Volume Discounts (Automatic)
 
-The more credits you use each month, the cheaper each credit becomes. Discounts apply automatically to different usage ranges within the same month.
+The more credits you use each month, the cheaper each credit becomes. Discounts are **banded**: they
+apply to the credits that fall inside each range, not retroactively to your whole bill.
 
-**Example:** If you use 150,000 credits on Starter tier:
+**Example:** if you use 150,000 credits in a month, the first 100,000 bill at your tier's base rate
+and the next 50,000 bill 10% cheaper.
 
-- First 100,000 credits: \$0.90 per 1000 credits
-- Next 50,000 credits: \$0.81 per 1000 credits (10% discount)
-- **Total cost:** \$90 + \$40.50 = \$130.50
+### **Discount Bands**
 
-### **Discount Tiers by Plan**
+The same bands apply to every tier. Only the base rate differs.
 
-<Tabs>
-<Tab title="Starter">
-
-| Credit usage per month  | Discount on credits in this range | Cost per 1000 credits |
-| ----------------------- | --------------------------------- | --------------------- |
-| 0 - 100,000             | 0%                                | $0.900                |
-| 100,001 - 1,000,000     | 10%                               | $0.810                |
-| 1,000,001 - 5,000,000   | 20%                               | $0.720                |
-| 5,000,001 - 10,000,000  | 30%                               | $0.630                |
-| 10,000,001 - 50,000,000 | 40%                               | $0.540                |
-| 50,000,000+             | 50%                               | $0.450                |
-
-</Tab>
-<Tab title="Creator">
-
-| Credit usage per month  | Discount on credits in this range | Cost per 1000 credits |
-| ----------------------- | --------------------------------- | --------------------- |
-| 0 - 100,000             | 0%                                | $1.200                |
-| 100,001 - 1,000,000     | 10%                               | $1.080                |
-| 1,000,001 - 5,000,000   | 20%                               | $0.960                |
-| 5,000,001 - 10,000,000  | 30%                               | $0.840                |
-| 10,000,001 - 50,000,000 | 40%                               | $0.720                |
-| 50,000,000+             | 50%                               | $0.600                |
-
-</Tab>
-<Tab title="Pro">
-
-| Credit usage per month  | Discount on credits in this range | Cost per 1000 credits |
-| ----------------------- | --------------------------------- | --------------------- |
-| 0 - 100,000             | 0%                                | $1.950                |
-| 100,001 - 1,000,000     | 10%                               | $1.755                |
-| 1,000,001 - 5,000,000   | 20%                               | $1.560                |
-| 5,000,001 - 10,000,000  | 30%                               | $1.365                |
-| 10,000,001 - 50,000,000 | 40%                               | $1.170                |
-| 50,000,000+             | 50%                               | $0.975                |
-
-</Tab>
-<Tab title="Business">
-
-| Credit usage per month  | Discount on credits in this range | Cost per 1000 credits |
-| ----------------------- | --------------------------------- | --------------------- |
-| 0 - 100,000             | 0%                                | $2.500                |
-| 100,001 - 1,000,000     | 10%                               | $2.250                |
-| 1,000,001 - 5,000,000   | 20%                               | $2.000                |
-| 5,000,001 - 10,000,000  | 30%                               | $1.750                |
-| 10,000,001 - 50,000,000 | 40%                               | $1.500                |
-| 50,000,000+             | 50%                               | $1.250                |
-
-</Tab>
-</Tabs>
+| Credit usage per month  | Discount on credits in this range |
+| ----------------------- | --------------------------------- |
+| 0 - 100,000             | 0%                                |
+| 100,001 - 1,000,000     | 10%                               |
+| 1,000,001 - 5,000,000   | 20%                               |
+| 5,000,001 - 10,000,000  | 30%                               |
+| 10,000,001 - 50,000,000 | 40%                               |
+| 50,000,000+             | 50%                               |
 
 <Note>Usage resets at midnight on the first of each month PST time</Note>
 
-## Practical Examples
+## Estimating Your Bill
 
-### **Small Developer (5,000 credits/month)**
+Two things set your monthly cost: the tier you're on, which fixes the base rate, and your monthly
+credit volume, which determines how much of that volume falls into discounted bands.
 
-- **Starter Tier**: 5,000 × \$0.0009 = **\$4.50/month**
-- **Creator Tier**: 5,000 × \$0.0012 = **\$6.00/month**
-
-_Choose Starter for basic resolution, Creator for higher quality_
-
-### **Growing Business (75,000 credits/month)**
-
-- **Starter Tier**: \$67.50/month (all at base rate)
-- **Creator Tier**: \$90/month (all at base rate)
-- **Pro Tier**: \$146.25/month (all at base rate)
-
-_Volume discounts kick in at 100,000+ credits_
-
-### **High Volume (500,000 credits/month)**
-
-**Starter Tier with volume discounts:**
-
-- First 100,000: \$90 (base rate)
-- Next 400,000: \$324 (10% discount)
-- **Total: \$414/month** (vs \$450 without discounts)
+- **Under 100,000 credits/month**: everything bills at your tier's base rate; no discount applies.
+- **Above 100,000 credits/month**: only the credits above each threshold get that band's discount,
+  so your effective rate falls gradually rather than dropping all at once.
 
 **Use our [cost calculator](https://magichour.ai/api#api-cost-calculator) for precise estimates with volume discounts included.**
 

--- a/get-started/authentication.mdx
+++ b/get-started/authentication.mdx
@@ -105,25 +105,18 @@ For security best practices, regularly rotate your API keys:
 ```python Python SDK
 from magic_hour import Client
 
-# Initialize client with your API key
-client = Client(token="your_api_key_here")
-
-# Or use environment variable
 import os
-client = Client(token=os.getenv("MAGIC_HOUR_API_KEY"))
+
+# Initialize client with your API key, or read it from an environment variable
+client = Client(token=os.getenv("MAGIC_HOUR_API_KEY", "your_api_key_here"))
 ```
 
 ```javascript Node.js SDK
 import { Client } from "magic-hour";
 
-// Initialize client with your API key
+// Initialize client with your API key, or read it from an environment variable
 const client = new Client({
-  token: "your_api_key_here",
-});
-
-// Or use environment variable
-const client = new Client({
-  token: process.env.MAGIC_HOUR_API_KEY,
+  token: process.env.MAGIC_HOUR_API_KEY ?? "your_api_key_here",
 });
 ```
 

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -117,7 +117,7 @@ magic-hour-tutorial/
 Install the Magic Hour Python SDK and python-dotenv for managing API keys:
 
 ```bash
-pip install magic-hour python-dotenv requests
+pip install magic_hour python-dotenv requests
 ```
 
 <Info>

--- a/integration/inputs-and-outputs.mdx
+++ b/integration/inputs-and-outputs.mdx
@@ -78,9 +78,12 @@ Magic Hour library URLs follow this pattern:
 # Use library URLs for assets
 result = client.v1.face_swap.create(
     assets={
-        "source_file_path": "https://magichour.ai/my-library?imageId=cmjag94dw01mr5s0zqf8ug0or",
-        "video_file_path": "https://magichour.ai/my-library?videoId=cmj86i5yy006x4m0z6znwowjb"
-    }
+        "image_file_path": "https://magichour.ai/my-library?imageId=cmjag94dw01mr5s0zqf8ug0or",
+        "video_file_path": "https://magichour.ai/my-library?videoId=cmj86i5yy006x4m0z6znwowjb",
+        "video_source": "file"
+    },
+    start_seconds=0,
+    end_seconds=5
 )
 ```
 
@@ -88,9 +91,12 @@ result = client.v1.face_swap.create(
 // Use library URLs for assets
 const result = await client.v1.faceSwap.create({
   assets: {
-    sourceFilePath: "https://magichour.ai/my-library?imageId=cmjag94dw01mr5s0zqf8ug0or",
+    imageFilePath: "https://magichour.ai/my-library?imageId=cmjag94dw01mr5s0zqf8ug0or",
     videoFilePath: "https://magichour.ai/my-library?videoId=cmj86i5yy006x4m0z6znwowjb",
+    videoSource: "file",
   },
+  startSeconds: 0,
+  endSeconds: 5,
 });
 ```
 

--- a/integration/webhook/event-types.mdx
+++ b/integration/webhook/event-types.mdx
@@ -8,7 +8,7 @@ description: Complete reference of all webhook events, payloads, and when they'r
 
 All webhook events follow a consistent structure with two main fields:
 
-```json
+```jsonc
 {
   "type": "event.name",
   "payload": {
@@ -90,7 +90,7 @@ Video events are triggered during the lifecycle of video processing jobs. All pa
 
 ```json
 {
-    "type": "video.completed",
+  "type": "video.completed",
   "payload": {
     "id": "clx7uu86w0a5qp55yxz315r6r",
     "status": "complete",

--- a/tools/image/meme-generator.mdx
+++ b/tools/image/meme-generator.mdx
@@ -27,7 +27,7 @@ AI Meme Generator creates humorous memes by combining popular meme templates wit
 
 ## How It Works
 
-1. **Choose a template** - Select from popular meme formats (Drake, Distracted Boyfriend, etc.)
+1. **Choose a template** - Select from popular meme formats (Drake Hotline Bling, Two Buttons, etc.)
 2. **Provide a topic** - Describe what the meme should be about
 3. **Optional web search** - Enable AI to search for relevant context
 4. **API generates text** - AI creates appropriate text for the meme panels
@@ -64,12 +64,16 @@ AI Meme Generator creates humorous memes by combining popular meme templates wit
 
 Popular templates work best with their intended formats:
 
-| Template             | Best For              | Example Topic                     |
-| :------------------- | :-------------------- | :-------------------------------- |
-| Drake Hotline Bling  | Preferences, choices  | "Old code vs new refactored code" |
-| Distracted Boyfriend | Conflicting interests | "Me, my project, new framework"   |
-| Two Buttons          | Difficult decisions   | "Fix bug or add feature"          |
-| Expanding Brain      | Progressive ideas     | "Levels of code optimization"     |
+| Template            | Best For             | Example Topic                       |
+| :------------------ | :------------------- | :---------------------------------- |
+| Drake Hotline Bling | Preferences, choices | "Old code vs new refactored code"   |
+| Gru's Plan          | Plans that backfire  | "Rewriting it in Rust to save time" |
+| Two Buttons         | Difficult decisions  | "Fix bug or add feature"            |
+| Galaxy Brain        | Progressive ideas    | "Levels of code optimization"       |
+
+`template` accepts one of: `Random`, `Drake Hotline Bling`, `Galaxy Brain`, `Two Buttons`, `Gru's Plan`,
+`Tuxedo Winnie The Pooh`, `Is This a Pigeon`, `Panik Kalm Panik`, `Disappointed Guy`, `Waiting Skeleton`,
+`Bike Fall`, `Change My Mind`, `Side Eyeing Chloe`. Any other value returns a 400.
 
 ### Web Search Option
 
@@ -166,7 +170,7 @@ else:
 const result = await client.v1.aiMemeGenerator.generate({
   style: {
     searchWeb: false,
-    template: "Distracted Boyfriend",
+    template: "Drake Hotline Bling",
     topic: "Developers and shiny new frameworks",
   },
   name: "Framework Meme",

--- a/tools/image/qr-code-generator.mdx
+++ b/tools/image/qr-code-generator.mdx
@@ -116,7 +116,7 @@ const client = new Client({ token: process.env.MAGIC_HOUR_API_KEY });
 const result = await client.v1.aiQrCodeGenerator.generate({
   content: "https://yourwebsite.com",
   style: {
-    prompt: "Ocean waves with blue and teal colors, flowing organic patterns",
+    artStyle: "Ocean waves with blue and teal colors, flowing organic patterns",
   },
   name: "Brand QR Code",
   waitForCompletion: true,
@@ -178,8 +178,8 @@ console.log(`✅ Downloaded to: ${result.downloadedPaths}`);
 
 <Tip>**Free** - Each QR code costs 0 credits.</Tip>
 
-| Output    | Credits           |
-| :-------- | :---------------- |
+| Output    | Credits          |
+| :-------- | :--------------- |
 | 1 QR code | 0 credits (free) |
 
 <Tip>

--- a/tools/video/auto-subtitle-generator.mdx
+++ b/tools/video/auto-subtitle-generator.mdx
@@ -106,6 +106,7 @@ const result = await client.v1.autoSubtitleGenerator.generate({
   },
   startSeconds: 0,
   endSeconds: 2,
+  style: { template: "karaoke" },
   name: "Subtitled Video",
   waitForCompletion: true,
   downloadOutputs: true,

--- a/tools/video/video-to-video.mdx
+++ b/tools/video/video-to-video.mdx
@@ -100,8 +100,6 @@ result = client.v1.video_to_video.generate(
     },
     end_seconds=2,
     fps_resolution="HALF",
-    height=512,
-    width=576,
     start_seconds=0,
     style={
         "art_style": "Retro Anime",
@@ -138,12 +136,10 @@ const result = await client.v1.videoToVideo.generate({
     videoSource: "file",
   },
   endSeconds: 2,
-  fps: 8,
-  height: 512,
-  width: 512,
+  fpsResolution: "HALF",
   startSeconds: 0,
   style: {
-    artStyle: "Studio Ghibli Film Still",
+    artStyle: "Studio Ghibli",
     prompt: "Obama dropping the mic in anime style, soft pastel colors, whimsical and expressive",
     promptType: "custom",
     version: "default",


### PR DESCRIPTION
First of three PRs from the docs audit triage. This one is only verified defects — every change is checked against `api-reference/openapi.json`, the live upstream spec, or the live pricing page. No judgment calls.

## API reference index

`api-reference/overview.mdx` listed all three Files endpoints under paths that don't exist in the spec (`/v1/files/generate-upload-urls`, `/v1/files/:id/face-detection`, `/v1/files/face-detection`). Corrected to `/v1/files/upload-urls`, `/v1/face-detection`, `/v1/face-detection/{id}`. The index now matches the spec on all 36 method+path pairs. Endpoint pages are generated from the spec with a CI drift gate; this page is hand-written and had none, which is why it drifted. A gate for it is in PR #2.

## Code samples that fail against the live API

| Page | Defect | Fix |
| :-- | :-- | :-- |
| `integration/inputs-and-outputs.mdx` | `face_swap.create` used `source_file_path` (not a field on this endpoint) and omitted required `start_seconds`, `end_seconds`, `assets.video_source` | Corrected to `image_file_path` + required fields |
| `tools/video/video-to-video.mdx` | JS passed `artStyle: "Studio Ghibli Film Still"` — belongs to Animation's enum, not this endpoint's 75 values; also `fps: 8` (no such field) and `height`/`width`, deprecated upstream and stripped from the published schema | `"Studio Ghibli"`, `fpsResolution: "HALF"`, deprecated params removed from both tabs |
| `tools/image/meme-generator.mdx` | JS used `template: "Distracted Boyfriend"`, not one of the 13 allowed values. The prose table also recommended two invalid templates | Valid templates throughout, plus the full allowed list |
| `tools/image/qr-code-generator.mdx` | JS passed `style.prompt` (not a field) and omitted required `style.art_style` | `artStyle` with the same descriptive value |
| `tools/video/auto-subtitle-generator.mdx` | JS omitted required `style` | Added `style: { template: "karaoke" }` |
| `get-started/authentication.mdx` | Declared `const client` twice in one block — `SyntaxError` on copy-paste | Single declaration with env-var fallback; Python tab matched |

## Consistency

- `integration/first-integration.mdx` said `pip install magic-hour` while every other page says `magic_hour`, which is the canonical PyPI name.
- The event structure block in `integration/webhook/event-types.mdx` contains a `//` comment, so it isn't parseable JSON. Marked `jsonc`.

## Pricing

Docs disagreed with magichour.ai/pricing on every Creator and Pro number, in both directions, and sold 1,000-credit packs at $3.00 that no longer exist (packs are 4,000/12,000/32,000 at $1 = 400 credits). Three worked examples were built on that pack price.

Dollar figures are removed rather than resynced — restating prices in docs is what caused the drift, and the next pricing change re-breaks it. Plan cards keep resolution ceilings and features; prices link to the pricing page. Usage-based volume discount bands are kept as percentages since those are mechanics, collapsed from four identical tables into one.

⚠️ One number I could not verify externally, because `/api` is client-rendered: the usage-based per-1,000-credit rates. Those dollar amounts are removed here, but if the tier structure itself changed, `billing/usage-based-pricing.mdx` needs a second look.

## Verification

- `yarn check` (broken links): passes
- Re-ran an enum + deprecated-param check across all 30 tool pages against the spec: no remaining violations
- Overview index diffed against spec: 36/36 match

Made with [Cursor](https://cursor.com)