### PR TITLE
feat: tag docs links to the developer hub and pricing for attribution

### DIFF
--- a/billing/overview.mdx
+++ b/billing/overview.mdx
@@ -57,7 +57,7 @@ Pay upfront for credits that never expire. Perfect for steady, predictable usage
 - **Business**: 4K resolution
 
 Current prices, credit allowances, and credit packs are on the
-[pricing page](https://magichour.ai/pricing).
+[pricing page](https://magichour.ai/pricing?ref=docs-billing-overview).
 
 <Card
   title="Subscription Details"
@@ -87,7 +87,7 @@ Pay only for what you use, with automatic volume discounts as you scale.
 - **Business**: 4K resolution
 
 Rates rise with the resolution tier and fall automatically with volume. Estimate your bill with the
-[API cost calculator](https://magichour.ai/api#api-cost-calculator).
+[API cost calculator](https://magichour.ai/api?ref=docs-billing-overview#api-cost-calculator).
 
 <Card title="Usage-Based Details" icon="chart-line" href="/billing/usage-based-pricing" horizontal>
   View usage-based pricing and discounts

--- a/billing/resolution-limits.mdx
+++ b/billing/resolution-limits.mdx
@@ -162,7 +162,7 @@ These APIs have maximum resolution limits regardless of subscription tier:
 
 ## Upgrading for Higher Resolution
 
-Need higher resolution? [Upgrade your subscription](https://magichour.ai/pricing) to unlock:
+Need higher resolution? [Upgrade your subscription](https://magichour.ai/pricing?ref=docs-resolution-limits) to unlock:
 
 - **Creator**: 2x larger dimensions (1024px vs 576px)
 - **Pro**: 2.5x larger dimensions (1472px vs 576px)

--- a/billing/subscription-pricing.mdx
+++ b/billing/subscription-pricing.mdx
@@ -38,8 +38,9 @@ description: Get credits upfront with predictable monthly or yearly billing and 
 Each plan offers different credit amounts and resolution limits. Higher plans unlock better resolution and more credits per month.
 
 <Info>
-  Prices and credit allowances live on the [pricing page](https://magichour.ai/pricing) so they're
-  always current. This page covers how the plans behave.
+  Prices and credit allowances live on the [pricing
+  page](https://magichour.ai/pricing?ref=docs-subscription-pricing) so they're always current. This
+  page covers how the plans behave.
 </Info>
 
 import { PricingCard } from "/snippets/pricing-card.mdx";
@@ -70,7 +71,12 @@ import { PricingCard } from "/snippets/pricing-card.mdx";
 />
 </CardGroup>
 
-<Card title="See plans and prices" icon="tag" href="https://magichour.ai/pricing" horizontal>
+<Card
+  title="See plans and prices"
+  icon="tag"
+  href="https://magichour.ai/pricing?ref=docs-subscription-pricing"
+  horizontal
+>
   Current monthly and annual pricing, credit allowances, and credit packs
 </Card>
 
@@ -80,7 +86,7 @@ If you use more credits than your plan includes, you can purchase additional cre
 
 ### **Credit Packs**
 
-- **Fixed pack sizes** - see the [pricing page](https://magichour.ai/pricing) for current sizes and prices
+- **Fixed pack sizes** - see the [pricing page](https://magichour.ai/pricing?ref=docs-subscription-pricing) for current sizes and prices
 - **Instant delivery** - credits added immediately to your account
 - **No expiration** - credits never expire, even after subscription ends
 
@@ -112,7 +118,7 @@ Ready to subscribe? Here's how to set up your subscription in minutes.
 
 <Steps>
 <Step title="Visit the Pricing Page">
-  Go to [magichour.ai/pricing](https://magichour.ai/pricing) to see all available plans and current pricing.
+  Go to [magichour.ai/pricing](https://magichour.ai/pricing?ref=docs-subscription-pricing) to see all available plans and current pricing.
   
   ![Pricing Page](./images/pricing-page-1.png)
 </Step>

--- a/billing/usage-based-pricing.mdx
+++ b/billing/usage-based-pricing.mdx
@@ -72,7 +72,7 @@ import { PricingCard } from "/snippets/pricing-card.mdx";
 
 Each tier has its own rate per 1,000 credits, rising with the resolution ceiling. Get current rates
 and model your monthly bill with the
-[API cost calculator](https://magichour.ai/api#api-cost-calculator).
+[API cost calculator](https://magichour.ai/api?ref=docs-usage-based-pricing#api-cost-calculator).
 
 ## Volume Discounts (Automatic)
 
@@ -106,7 +106,7 @@ credit volume, which determines how much of that volume falls into discounted ba
 - **Above 100,000 credits/month**: only the credits above each threshold get that band's discount,
   so your effective rate falls gradually rather than dropping all at once.
 
-**Use our [cost calculator](https://magichour.ai/api#api-cost-calculator) for precise estimates with volume discounts included.**
+**Use our [cost calculator](https://magichour.ai/api?ref=docs-usage-based-pricing#api-cost-calculator) for precise estimates with volume discounts included.**
 
 ## Getting Started
 
@@ -136,7 +136,7 @@ credit volume, which determines how much of that volume falls into discounted ba
 
 ## Tracking usage
 
-In the [Developer Hub](https://magichour.ai/developer), you can see your usage analytics for specific time ranges.
+In the [Developer Hub](https://magichour.ai/developer?ref=docs-usage-based-pricing), you can see your usage analytics for specific time ranges.
 
 ![Usage Analytics](./images/usage-analytics.png)
 

--- a/docs.json
+++ b/docs.json
@@ -36,7 +36,7 @@
     "primary": {
       "type": "button",
       "label": "Dashboard",
-      "href": "https://magichour.ai/developer"
+      "href": "https://magichour.ai/developer?ref=docs-navbar"
     }
   },
   "footer": {

--- a/get-started/authentication.mdx
+++ b/get-started/authentication.mdx
@@ -24,7 +24,7 @@ Visit [magichour.ai](https://magichour.ai/sign-up) and sign in to your account. 
 </Step>
 
 <Step title="Navigate to Developer Hub">
-Once signed in, go directly to the [API Keys section of the Developer Hub](https://magichour.ai/developer?tab=api-keys).
+Once signed in, go directly to the [API Keys section of the Developer Hub](https://magichour.ai/developer?tab=api-keys&ref=docs-authentication).
 
 ![Developer Hub with API Keys](./images/navigate-to-developer-hub.jpg)
 

--- a/get-started/quick-start.mdx
+++ b/get-started/quick-start.mdx
@@ -134,10 +134,10 @@ import SdkInstallation from "/snippets/code-groups/sdk-installation.mdx";
 **What we're doing:** Submit a generation job, wait for Magic Hour to render it, then download the
 result. Choose the example that matches what you want to build:
 
-| Example             | Best for                  | Typical cost                     | Typical wait  |
-| :------------------ | :------------------------ | :------------------------------- | :------------ |
-| **Generate image**  | Cheapest first success    | 5 credits                        | 5-30 seconds  |
-| **Face swap video** | Our most popular API path | ~200 credits for the sample clip | 2-5 minutes   |
+| Example             | Best for                  | Typical cost                     | Typical wait |
+| :------------------ | :------------------------ | :------------------------------- | :----------- |
+| **Generate image**  | Cheapest first success    | 5 credits                        | 5-30 seconds |
+| **Face swap video** | Our most popular API path | ~200 credits for the sample clip | 2-5 minutes  |
 
 ### Copy the code and run it
 
@@ -790,16 +790,16 @@ Authentication guide for platform-specific setup steps.
 
 If you encounter HTTP errors, here's what they mean:
 
-| Error Code | Meaning               | Solution                                                                          |
-| :--------- | :-------------------- | :-------------------------------------------------------------------------------- |
-| `400`      | Bad Request           | The response `message` names the invalid or missing field - fix it and resubmit   |
-| `401`      | Unauthorized          | Verify your API key is correct and sent as `Authorization: Bearer <key>`          |
-| `402`      | Payment Required      | Insufficient credits - [add more credits](https://magichour.ai/dashboard/my-plan) |
-| `403`      | Forbidden             | Your key is valid but the model, resolution, or feature is not available on your plan |
-| `429`      | Too Many Requests     | You are sending requests too quickly - retry with exponential backoff             |
-| `500`      | Internal Server Error | Temporary server issue - retry after a few seconds                                |
+| Error Code | Meaning               | Solution                                                                                                                                |
+| :--------- | :-------------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`      | Bad Request           | The response `message` names the invalid or missing field - fix it and resubmit                                                         |
+| `401`      | Unauthorized          | Verify your API key is correct and sent as `Authorization: Bearer <key>`                                                                |
+| `402`      | Payment Required      | Insufficient credits - [add more credits](https://magichour.ai/dashboard/my-plan?ref=docs-quickstart-402)                               |
+| `403`      | Forbidden             | Your key is valid but the model, resolution, or feature is not available on your plan                                                   |
+| `429`      | Too Many Requests     | You are sending requests too quickly - retry with exponential backoff                                                                   |
+| `500`      | Internal Server Error | Temporary server issue - retry after a few seconds                                                                                      |
 | `502`      | Bad Gateway           | Server temporarily unavailable - retry after 30-60 seconds. If it failed before returning a project `id`, no job was created - resubmit |
-| `503`      | Service Unavailable   | Server overloaded - retry with exponential backoff                                |
+| `503`      | Service Unavailable   | Server overloaded - retry with exponential backoff                                                                                      |
 
 **For persistent errors:** Contact [support@magichour.ai](mailto:support@magichour.ai) with your project ID.
 

--- a/integration/adding-api-to-your-app.mdx
+++ b/integration/adding-api-to-your-app.mdx
@@ -23,7 +23,7 @@ By the end of this guide, you'll have:
 
 **Prerequisites:**
 
-- API key from [Developer Hub](https://magichour.ai/developer?tab=api-keys)
+- API key from [Developer Hub](https://magichour.ai/developer?tab=api-keys&ref=docs-adding-api-to-your-app)
 - Your preferred SDK installed or direct HTTP client ready
 
 <Warning>

--- a/integration/first-integration.mdx
+++ b/integration/first-integration.mdx
@@ -74,7 +74,8 @@ In this tutorial, you'll create a working application that generates an AI image
 
 <Note>
   **Estimated time**: 15-20 minutes **Prerequisites**: API key from [Developer
-  Hub](https://magichour.ai/developer?tab=api-keys), Python 3.8+ or Node.js 16+ installed
+  Hub](https://magichour.ai/developer?tab=api-keys&ref=docs-first-integration), Python 3.8+ or
+  Node.js 16+ installed
 </Note>
 
 ## Choose Your Language

--- a/integration/webhook/create-webhook.mdx
+++ b/integration/webhook/create-webhook.mdx
@@ -268,7 +268,7 @@ Ensure your production server:
 
 <Steps>
 <Step title="Visit Developer Hub">
-Go to Magic Hour [Developer Hub](https://magichour.ai/developer?tab=webhooks), and click **Create Webhook**
+Go to Magic Hour [Developer Hub](https://magichour.ai/developer?tab=webhooks&ref=docs-create-webhook), and click **Create Webhook**
 
 ![Webhook Table](./images/webhook-1.png)
 

--- a/integration/webhook/overview.mdx
+++ b/integration/webhook/overview.mdx
@@ -272,7 +272,7 @@ ngrok http 8000
 
 <Steps>
 <Step title="Visit Developer Hub">
-Go to Magic Hour [Developer Hub](https://magichour.ai/developer?tab=webhooks), and click **Create Webhook**
+Go to Magic Hour [Developer Hub](https://magichour.ai/developer?tab=webhooks&ref=docs-webhook-overview), and click **Create Webhook**
 
 ![Webhook Table](./images/webhook-1.png)
 


### PR DESCRIPTION
Third of three PRs from the docs audit triage. Stacked on #441, which is stacked on #440. Base retargets as those merge.

Not from the audit — this comes from the funnel data. Docs already run PostHog and GA4, but of the twelve links pointing from docs to the developer hub, exactly one (`get-started/quick-start.mdx`) carried a `ref` param. So today we cannot answer whether any docs change moved API-key creation, which makes the rest of the audit work unmeasurable.

Every outbound conversion link now carries `ref=docs-<page-slug>`, following the existing `ref=docs-quickstart` convention.

**Key creation** — `docs.json` navbar Dashboard button, `get-started/authentication.mdx`, `integration/first-integration.mdx`, `integration/adding-api-to-your-app.mdx`, `integration/webhook/overview.mdx`, `integration/webhook/create-webhook.mdx`, `billing/usage-based-pricing.mdx`.

**Monetization** — pricing links in `billing/overview.mdx`, `billing/subscription-pricing.mdx`, `billing/resolution-limits.mdx`; the cost calculator from both billing pages; and the "add more credits" link on the `402` row of the quick-start error table, which is the one place in docs a developer lands after being blocked by credits.

Deliberately untagged: changelog entries (historical), and links inside `openapi.json` (regenerated nightly from upstream, so a change here reverts).

`get-started/quick-start.mdx` shows more diff than expected because the longer URL made prettier re-align two markdown tables. No content change.

## Verification

- `yarn check` (broken links): passes
- `yarn check:api-drift`: passes

Made with [Cursor](https://cursor.com)