### PR TITLE
feat: add a models and credit costs reference

### DIFF
--- a/api-reference/models.mdx
+++ b/api-reference/models.mdx
@@ -42,7 +42,7 @@ Credits per second of output. Multiply by your `end_seconds` to estimate a job.
 | Model          | 480p | 720p | 1080p |  4k | With audio |
 | :------------- | ---: | ---: | ----: | --: | :--------- |
 | `wan-2.2`      |   24 |   48 |    72 |   — | —          |
-| `kling-3.0`    |    — |   48 |    72 |   — | +24        |
+| `kling-3.0`    |    — |   48 |    72 | 240 | +24        |
 | `veo3.1-lite`  |    — |   48 |    72 |   — | +24        |
 | `veo3.1`       |    — |   96 |   120 |   — | +24        |
 | `seedance-2.0` |  144 |  288 |     — |   — | —          |

--- a/api-reference/models.mdx
+++ b/api-reference/models.mdx
@@ -39,14 +39,14 @@ Available on [text to video](/api-reference/video-projects/text-to-video) and
 
 Credits per second of output. Multiply by your `end_seconds` to estimate a job.
 
-| Model          | 480p | 720p | 1080p |  4k | With audio |
-| :------------- | ---: | ---: | ----: | --: | :--------- |
-| `wan-2.2`      |   24 |   48 |    72 |   — | —          |
-| `kling-3.0`    |    — |   48 |    72 | 240 | +24        |
-| `veo3.1-lite`  |    — |   48 |    72 |   — | +24        |
-| `veo3.1`       |    — |   96 |   120 |   — | +24        |
-| `seedance-2.0` |  144 |  288 |     — |   — | —          |
-| `sora-2`       |    — |  120 |     — |   — | Included   |
+| Model          | 480p | 720p | 1080p |  4k | With audio                    |
+| :------------- | ---: | ---: | ----: | --: | :---------------------------- |
+| `wan-2.2`      |   24 |   48 |    72 |   — | —                             |
+| `kling-3.0`    |    — |   48 |    72 | 240 | +24 at 720p, 1080p; +48 at 4k |
+| `veo3.1-lite`  |    — |   48 |    72 |   — | +24                           |
+| `veo3.1`       |    — |   96 |   120 |   — | +24                           |
+| `seedance-2.0` |  144 |  288 |     — |   — | —                             |
+| `sora-2`       |    — |  120 |     — |   — | Included                      |
 
 <Warning>
   Per-second costs for `ltx-2.3`, `kling-2.6`, `seedance-1.5`, `seedance-2.0-mini`, `seedance-2.5`

--- a/api-reference/models.mdx
+++ b/api-reference/models.mdx
@@ -1,0 +1,163 @@
+---
+title: "Models and Credit Costs"
+sidebarTitle: "Models"
+description: "Every model available through the API, what it supports, and what it costs in credits."
+---
+
+Magic Hour exposes multiple models per endpoint. Pass the one you want in the `model` field, or
+omit it to get `default`, which tracks our current recommendation and changes over time.
+
+Credits are charged per generation. Video cost scales with duration, image cost with resolution and
+image count. Failed generations are never charged.
+
+## Video models
+
+Available on [text to video](/api-reference/video-projects/text-to-video) and
+[image to video](/api-reference/video-projects/image-to-video).
+
+| Model               | Best for                                                  | Resolutions       | Durations (seconds)                                                                                  | Audio                 |
+| :------------------ | :-------------------------------------------------------- | :---------------- | :--------------------------------------------------------------------------------------------------- | :-------------------- |
+| `ltx-2.3`           | Fastest output. Best for rapid iteration                  | 480p, 720p, 1080p | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30                                                        | Yes, no extra credits |
+| `wan-2.2`           | Strong physics, camera moves, and motion                  | 480p, 720p, 1080p | 3, 4, 5, 6, 7, 8, 9, 10, 15                                                                          | No                    |
+| `kling-2.6`         | Great for action, motion blur, and camera moves           | 720p, 1080p       | 5, 10                                                                                                | No                    |
+| `kling-3.0`         | Best overall quality for cinematic storytelling           | 720p, 1080p, 4k   | 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15                                                          | Yes, costs extra      |
+| `veo3.1-lite`       | Veo quality at a more accessible cost                     | 720p, 1080p       | 4, 6, 8, 16, 24, 32, 40, 48, 56                                                                      | Yes, costs extra      |
+| `veo3.1`            | Google's model. Highest realism and detail                | 720p, 1080p       | 4, 6, 8, 16, 24, 32, 40, 48, 56                                                                      | Yes, costs extra      |
+| `seedance-1.5`      | Smooth, consistent motion with precision                  | 480p, 720p, 1080p | 4, 5, 6, 7, 8, 9, 10, 11, 12                                                                         | Yes, costs extra      |
+| `seedance-2.0-mini` | Fast, consistent video with strong motion quality         | 480p, 720p        | 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15                                                             | Yes, no extra credits |
+| `seedance-2.0`      | Top quality with reference-to-video control               | 480p, 720p        | 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15                                                             | Yes, no extra credits |
+| `seedance-2.5`      | Highest quality with superior realism, detail, and motion | 480p, 720p        | 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 | Yes, no extra credits |
+| `sora-2`            | Open AI's model. Great for creativity and viral clips     | 720p              | 4, 8, 12, 24, 36, 48, 60                                                                             | Yes, no extra credits |
+
+<Note>
+  `default` resolves to `kling-3.0` on paid tiers and `ltx-2.3` on the free tier. The deprecated
+  `kling-2.5-audio` and `veo3.1-audio` values are equivalent to passing the base model with `audio:
+  true`.
+</Note>
+
+### Video credit costs
+
+Credits per second of output. Multiply by your `end_seconds` to estimate a job.
+
+| Model          | 480p | 720p | 1080p |  4k | With audio |
+| :------------- | ---: | ---: | ----: | --: | :--------- |
+| `wan-2.2`      |   24 |   48 |    72 |   — | —          |
+| `kling-3.0`    |    — |   48 |    72 |   — | +24        |
+| `veo3.1-lite`  |    — |   48 |    72 |   — | +24        |
+| `veo3.1`       |    — |   96 |   120 |   — | +24        |
+| `seedance-2.0` |  144 |  288 |     — |   — | —          |
+| `sora-2`       |    — |  120 |     — |   — | Included   |
+
+<Warning>
+  Per-second costs for `ltx-2.3`, `kling-2.6`, `seedance-1.5`, `seedance-2.0-mini`, `seedance-2.5`
+  are not listed above. Use the [cost
+  calculator](https://magichour.ai/api?ref=docs-models#api-cost-calculator) for these models, or
+  read `credits_charged` on the create response before the render starts.
+</Warning>
+
+The video formula is `duration × output fps × resolution multiplier`. Because output fps varies by
+model, two models at the same resolution can cost different amounts per second.
+
+### Legacy model values
+
+The endpoints still accept `ltx-2`, `kling-2.5`, `kling-1.6`, `seedance` for backwards
+compatibility, but these are no longer recommended and are absent from the tables above. New
+integrations should use a documented model.
+
+[AI video editor](/api-reference/video-projects/ai-video-editor) has its own roster: `gemini-omni`
+and `ltx-2.3`, defaulting to `ltx-2.3` on the free tier and `gemini-omni` on paid tiers.
+
+## Image models
+
+Available on [AI image generator](/api-reference/image-projects/ai-image-generator) and
+[AI image editor](/api-reference/image-projects/ai-image-editor).
+
+| Model                | Generate | Edit | Resolutions       |        From | Tiers                        |
+| :------------------- | :------- | :--- | :---------------- | ----------: | :--------------------------- |
+| `flux-schnell`       | Yes      | —    | 640px, 1k, 2k     |   5 credits | free, creator, pro, business |
+| `flux-2-klein`       | Yes      | Yes  | 640px, 1k, 2k     |   5 credits | free, creator, pro, business |
+| `z-image-turbo`      | Yes      | —    | 640px, 1k, 2k     |   5 credits | free, creator, pro, business |
+| `seedream-v4`        | Yes      | Yes  | 640px, 1k, 2k, 4k |  40 credits | creator, pro, business       |
+| `seedream-v5-pro`    | Yes      | Yes  | 640px, 1k, 2k     |  75 credits | creator, pro, business       |
+| `nano-banana`        | Yes      | Yes  | 640px, 1k         |  50 credits | creator, pro, business       |
+| `nano-banana-2-lite` | Yes      | Yes  | 640px, 1k         |  50 credits | creator, pro, business       |
+| `nano-banana-2`      | Yes      | Yes  | 640px, 1k, 2k, 4k | 100 credits | creator, pro, business       |
+| `nano-banana-pro`    | Yes      | Yes  | 1k, 2k, 4k        | 150 credits | creator, pro, business       |
+| `gpt-image-2`        | Yes      | Yes  | 640px, 1k, 2k, 4k |  50 credits | creator, pro, business       |
+| `qwen-edit`          | —        | Yes  | 640px, 1k, 2k     |  10 credits | free, creator, pro, business |
+| `seedream-v4.5`      | —        | Yes  | 640px, 1k, 2k, 4k |  50 credits | creator, pro, business       |
+
+"From" is the cost of a single image at the model's lowest resolution. Higher resolutions cost more,
+and generating multiple images multiplies the cost.
+
+| Model                | Max images per request (generator) | Max additional input images (editor) |
+| :------------------- | :--------------------------------- | :----------------------------------- |
+| `flux-schnell`       | 1, 2, 3, 4                         | —                                    |
+| `flux-2-klein`       | 1                                  | 5                                    |
+| `z-image-turbo`      | 1, 2, 3, 4                         | —                                    |
+| `seedream-v4`        | 1, 2, 3, 4                         | 9                                    |
+| `seedream-v5-pro`    | 1, 2, 3, 4                         | 9                                    |
+| `nano-banana`        | 1, 2, 3, 4                         | 9                                    |
+| `nano-banana-2-lite` | 1, 2, 3, 4                         | 9                                    |
+| `nano-banana-2`      | 1, 4, 9, 16                        | 9                                    |
+| `nano-banana-pro`    | 1, 4, 9, 16                        | 9                                    |
+| `gpt-image-2`        | 1, 2, 3, 4                         | 9                                    |
+| `qwen-edit`          | —                                  | 2                                    |
+| `seedream-v4.5`      | —                                  | 9                                    |
+
+## Fixed-cost endpoints
+
+These endpoints have a single model and a flat rate.
+
+| Endpoint                                                                           | Credits                                  |
+| :--------------------------------------------------------------------------------- | :--------------------------------------- |
+| [AI Clothes Changer](/api-reference/image-projects/ai-clothes-changer)             | 25 per image                             |
+| [AI Face Editor](/api-reference/image-projects/ai-face-editor)                     | 1 per edit                               |
+| [AI GIF Generator](/api-reference/image-projects/ai-gif-generator)                 | 50 per GIF                               |
+| [AI Headshot Generator](/api-reference/image-projects/ai-headshot-generator)       | 50 per headshot                          |
+| [AI Meme Generator](/api-reference/image-projects/ai-meme-generator)               | 10 per meme                              |
+| [AI QR Code Generator](/api-reference/image-projects/ai-qr-code-generator)         | Free                                     |
+| [Body Swap](/api-reference/image-projects/body-swap)                               | 100 per image                            |
+| [Face Swap Photo](/api-reference/image-projects/face-swap-photo)                   | 10 per image                             |
+| [Head Swap](/api-reference/image-projects/head-swap)                               | 10 per image                             |
+| [Image Background Remover](/api-reference/image-projects/image-background-remover) | 5 per image                              |
+| [Photo Colorizer](/api-reference/image-projects/photo-colorizer)                   | 10 per image                             |
+| [AI Voice Generator](/api-reference/audio-projects/ai-voice-generator)             | 0.05 per character, rounded up           |
+| [AI Voice Cloner](/api-reference/audio-projects/ai-voice-cloner)                   | 0.05 per generated character, rounded up |
+
+### AI Image Upscaler
+
+Cost depends on `style.mode` and `scale_factor`.
+
+| Mode and scale               | Credits       |
+| :--------------------------- | :------------ |
+| `preserve`, 2x               | 25 per image  |
+| `balanced` or `creative`, 2x | 50 per image  |
+| `preserve`, 4x               | 100 per image |
+| `balanced` or `creative`, 4x | 200 per image |
+
+## Duration-based endpoints
+
+These charge by output length rather than per generation.
+
+| Endpoint                                                                         | Credits                                            |
+| :------------------------------------------------------------------------------- | :------------------------------------------------- |
+| [Animation](/api-reference/video-projects/animation)                             | 24 credits/second at 24fps                         |
+| [Audio to Video](/api-reference/video-projects/audio-to-video)                   | 24 credits/second at 480p, 48 at 720p, 72 at 1080p |
+| [Auto Subtitle Generator](/api-reference/video-projects/auto-subtitle-generator) | ~4.8 credits/second at 24fps                       |
+| [Face Swap Video](/api-reference/video-projects/face-swap-video)                 | 24 credits/second at 24fps                         |
+| [Lip Sync](/api-reference/video-projects/lip-sync)                               | 1 credit/frame, doubled on `pro`                   |
+| [AI Talking Photo](/api-reference/video-projects/ai-talking-photo)               | 20 credits/second prompted, 48 realistic           |
+| [Video to Video](/api-reference/video-projects/video-to-video)                   | 48 credits/second at 24fps                         |
+
+<Info>
+  Video jobs return an estimate in `credits_charged` on the create response, calculated at 30fps.
+  The final amount is corrected once the render finishes and the true frame rate is known. Read
+  `credits_charged` from the get-details response for the actual charge.
+</Info>
+
+## Estimating before you build
+
+- **Cost calculator** — [model your monthly spend](https://magichour.ai/api?ref=docs-models#api-cost-calculator) across endpoints and volumes.
+- **Mock server** — [develop against sample responses](/integration/development-and-testing#mock-server-recommended-for-development) without spending credits.
+- **Free tier** — 400 credits on signup plus 100 daily credits, enough to exercise every image endpoint and short video jobs.

--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -7,6 +7,9 @@ Magic Hour APIs create and manage video, image, and audio projects. Most creatio
 a project ID immediately; use the matching details endpoint or a webhook to track completion.
 
 <CardGroup cols={2}>
+  <Card title="Models and credit costs" icon="layer-group" href="/api-reference/models">
+    Compare every model's resolutions, durations, and cost.
+  </Card>
   <Card title="Processing times" icon="clock" href="/api-reference/processing-times">
     See observed median end-to-end times.
   </Card>

--- a/docs.json
+++ b/docs.json
@@ -164,6 +164,7 @@
         "openapi": "api-reference/openapi.json",
         "pages": [
           "api-reference/overview",
+          "api-reference/models",
           "api-reference/processing-times",
           {
             "group": "Files",


### PR DESCRIPTION
Fourth PR, stacked on #442. This is the audit's "no comprehensive list of all models" finding, which I ranked as the highest-value new page: text-to-video and image-to-video are your #4 and #5 traffic pages and each accepts 18 model values.

New page at `/api-reference/models`, linked from the reference index and the API Reference sidebar.

## What's in it

**Video models** — one row per model with quality guidance, supported resolutions, supported durations, and audio behavior. All four of those live in separate field descriptions on the endpoint today (`model`, `resolution`, `end_seconds`, `audio`), so answering "can kling-2.6 do 12 seconds at 1080p" currently means reading four blobs and cross-referencing them. Derived from the spec, so it's accurate by construction.

**Video credit costs** — credits per second by resolution, with the audio surcharge called out. Includes the formula (`duration × output fps × resolution multiplier`) and the reason two models at the same resolution can differ: output fps varies by model.

**Image models** — a single table spanning both the generator and the editor, showing which models do which, resolutions, starting cost, and tier availability, plus max image count per request. The spec already carries per-model costs for images; this just pivots them into one place.

**Fixed-cost and duration-based endpoints** — flat rates for the 13 single-model endpoints, the upscaler's mode/scale matrix, and per-second rates for the seven duration-based video endpoints.

**Legacy values** — `ltx-2`, `kling-2.5`, `kling-1.6`, and `seedance` are still accepted but no longer documented upstream. Listed so an agent reading old code can recognize them, kept out of the comparison tables so nobody picks one.

## Gaps, flagged rather than filled

Five video models have no cost in the pricing snapshot: `ltx-2.3`, `kling-2.6`, `seedance-1.5`, `seedance-2.0-mini`, `seedance-2.5`. `ltx-2.3` matters most since it's the free-tier default, so it's the first model a new API user hits. Marked with a warning pointing at the cost calculator instead of guessing.

Two smaller inconsistencies worth a look from whoever owns pricing config:

- `kling-3.0` advertises 4k support in the spec, but the config has no 4k multiplier.
- The spec says `seedance-2.0` supports audio at no extra credits; the pricing config leaves `multiplierWithAudio` undefined, which its own contract reads as no audio support. The page follows the spec, since that's the API contract, but one of the two is wrong.

## Verification

- `yarn check` (broken links): passes
- `yarn check:api-drift`: passes
- Every model value on the page cross-checked against the endpoint enums; no model is listed that the API doesn't accept, and no accepted model is missing

Made with [Cursor](https://cursor.com)